### PR TITLE
Fix issue with dlc close 0 payout out of range

### DIFF
--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -1275,12 +1275,18 @@ Payout Group not found',
         const payout = initiatorPayouts[i];
 
         offerPayoutValue = isOfferer
-          ? closeInputAmount + payout - finalizer.offerInitiatorFees
+          ? closeInputAmount +
+            (payout === BigInt(0)
+              ? payout
+              : payout - finalizer.offerInitiatorFees)
           : dlcOffer.contractInfo.totalCollateral - payout;
 
         acceptPayoutValue = isOfferer
           ? dlcOffer.contractInfo.totalCollateral - payout
-          : closeInputAmount + payout - finalizer.offerInitiatorFees;
+          : closeInputAmount +
+            (payout === BigInt(0)
+              ? payout
+              : payout - finalizer.offerInitiatorFees);
       } else {
         const dlcClose = checkTypes({ _dlcClose: _dlcCloses[i] }).dlcClose;
 
@@ -1288,16 +1294,21 @@ Payout Group not found',
         acceptPayoutValue = dlcClose.acceptPayoutSatoshis;
       }
 
-      const txOuts = [
-        {
+      const txOuts = [];
+
+      if (Number(offerPayoutValue) > 0) {
+        txOuts.push({
           address: address.fromOutputScript(dlcOffer.payoutSPK, network),
           amount: Number(offerPayoutValue),
-        },
-        {
+        });
+      }
+
+      if (Number(acceptPayoutValue) > 0) {
+        txOuts.push({
           address: address.fromOutputScript(dlcAccept.payoutSPK, network),
           amount: Number(acceptPayoutValue),
-        },
-      ];
+        });
+      }
 
       if (dlcOffer.payoutSerialId <= dlcAccept.payoutSerialId) txOuts.reverse();
 

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -270,7 +270,7 @@ describe('dlc provider', () => {
           dlcOffer,
           dlcAccept,
           dlcTransactions,
-          Array.from(Array(250).keys()).map((n) => BigInt(n + 10000)),
+          [0n, ...Array.from(Array(250).keys()).map((n) => BigInt(n + 10000))],
           true,
         );
         console.timeEnd('batch-close');


### PR DESCRIPTION
This PR fixes issue with DlcClose with payout `0` being out of range

It ensures payout amount cannot be negative, and only out output in transaction if `offerPayout` or `acceptPayout` is 0