### PR TITLE
✅test: fix unit for bits in custom oracle test

### DIFF
--- a/packages/bitcoin-js-wallet-provider/package.json
+++ b/packages/bitcoin-js-wallet-provider/package.json
@@ -32,7 +32,7 @@
     "bip32": "^2.0.6",
     "bip39": "^3.0.2",
     "bitcoin-networks": "^1.0.0",
-    "bitcoinjs-lib": "^5.2.0",
+    "bitcoinjs-lib": "5.2.0",
     "bitcoinjs-message": "^2.1.0",
     "secp256k1": "^4.0.3"
   },

--- a/packages/bitcoin-node-wallet-provider/package.json
+++ b/packages/bitcoin-node-wallet-provider/package.json
@@ -33,7 +33,7 @@
     "@babel/runtime": "^7.12.1",
     "bignumber.js": "^9.0.0",
     "bitcoin-networks": "^1.0.0",
-    "bitcoinjs-lib": "^5.2.0",
+    "bitcoinjs-lib": "5.2.0",
     "lodash": "^4.17.20"
   },
   "homepage": "https://github.com/atomicfinance/chainabstractionlayer#readme",

--- a/packages/bitcoin-utils/package.json
+++ b/packages/bitcoin-utils/package.json
@@ -32,7 +32,7 @@
     "bignumber.js": "^9.0.0",
     "bip174": "^2.0.1",
     "bitcoin-networks": "^1.0.0",
-    "bitcoinjs-lib": "^5.2.0",
+    "bitcoinjs-lib": "5.2.0",
     "coinselect": "^3.1.11",
     "lodash": "^4.17.20"
   },

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,7 +30,7 @@
     "bignumber.js": "^9.0.0",
     "bip174": "^2.0.1",
     "bitcoin-networks": "^1.0.0",
-    "bitcoinjs-lib": "^5.2.0",
+    "bitcoinjs-lib": "5.2.0",
     "coinselect": "^3.1.11",
     "lodash": "^4.17.20",
     "setimmediate": "^1.0.5"

--- a/tests/integration/dlc/custom-oracle.test.ts
+++ b/tests/integration/dlc/custom-oracle.test.ts
@@ -50,7 +50,7 @@ describe.skip('Custom Strategy Oracle POC numdigits=18', () => {
   );
   const intervals = [{ beginInterval: 0n, roundingMod: 25000n }];
   const totalCollateralIn = 120000000n;
-  const unit = 'Bits';
+  const unit = 'Bits * 10^-1';
   const eventId = 'strategyOutcome';
 
   const outcome = 10500;

--- a/tests/integration/utils/WrappedCfdDlcJs.ts
+++ b/tests/integration/utils/WrappedCfdDlcJs.ts
@@ -4,7 +4,7 @@ import { StaticPool } from 'node-worker-threads-pool';
 const FILE_PATH = './tests/integration/utils/cfdDlcJsWorker.js';
 
 const pool = new StaticPool({
-  size: 4,
+  size: 2,
   task: FILE_PATH,
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-cfd-provider@workspace:packages/bitcoin-cfd-provider"
   dependencies:
-    "@atomicfinance/provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
@@ -32,10 +32,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-dlc-provider@workspace:packages/bitcoin-dlc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": 3.0.0
-    "@atomicfinance/provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-utils": 3.0.1
+    "@atomicfinance/provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@node-dlc/core": 0.19.1
     "@node-dlc/messaging": 0.19.1
     "@node-lightning/bitcoin": 0.26.1
@@ -53,16 +53,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-esplora-api-provider@^3.0.0, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
+"@atomicfinance/bitcoin-esplora-api-provider@^3.0.1, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.0.0
-    "@atomicfinance/crypto": ^3.0.0
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/node-provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-utils": ^3.0.1
+    "@atomicfinance/crypto": ^3.0.1
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/node-provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -76,10 +76,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-batch-api-provider@workspace:packages/bitcoin-esplora-batch-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-esplora-api-provider": ^3.0.0
-    "@atomicfinance/node-provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-esplora-api-provider": ^3.0.1
+    "@atomicfinance/node-provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -92,15 +92,15 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-js-wallet-provider@workspace:packages/bitcoin-js-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.0.0
-    "@atomicfinance/bitcoin-wallet-provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-utils": ^3.0.1
+    "@atomicfinance/bitcoin-wallet-provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     bip32: ^2.0.6
     bip39: ^3.0.2
     bitcoin-networks: ^1.0.0
-    bitcoinjs-lib: ^5.2.0
+    bitcoinjs-lib: 5.2.0
     bitcoinjs-message: ^2.1.0
     secp256k1: ^4.0.3
   languageName: unknown
@@ -110,16 +110,16 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-node-wallet-provider@workspace:packages/bitcoin-node-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.0.0
-    "@atomicfinance/crypto": ^3.0.0
-    "@atomicfinance/jsonrpc-provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-utils": ^3.0.1
+    "@atomicfinance/crypto": ^3.0.1
+    "@atomicfinance/jsonrpc-provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
     bitcoin-networks: ^1.0.0
-    bitcoinjs-lib: ^5.2.0
+    bitcoinjs-lib: 5.2.0
     lodash: ^4.17.20
   languageName: unknown
   linkType: soft
@@ -128,11 +128,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-rpc-provider@workspace:packages/bitcoin-rpc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.0.0
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/jsonrpc-provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/bitcoin-utils": ^3.0.1
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/jsonrpc-provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -141,14 +141,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-utils@3.0.0, @atomicfinance/bitcoin-utils@^3.0.0, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
+"@atomicfinance/bitcoin-utils@3.0.1, @atomicfinance/bitcoin-utils@^3.0.1, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.0.0
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
-    "@atomicfinance/utils": ^3.0.0
+    "@atomicfinance/crypto": ^3.0.1
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
+    "@atomicfinance/utils": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/bitcoinjs-lib": ^5.0.0
     "@types/lodash": ^4.14.168
@@ -156,19 +156,19 @@ __metadata:
     bignumber.js: ^9.0.0
     bip174: ^2.0.1
     bitcoin-networks: ^1.0.0
-    bitcoinjs-lib: ^5.2.0
+    bitcoinjs-lib: 5.2.0
     coinselect: ^3.1.11
     lodash: ^4.17.20
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-wallet-provider@^3.0.0, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
+"@atomicfinance/bitcoin-wallet-provider@^3.0.1, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.0.0
-    "@atomicfinance/provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
+    "@atomicfinance/bitcoin-utils": ^3.0.1
+    "@atomicfinance/provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     bitcoin-networks: ^1.0.0
@@ -182,9 +182,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/client@workspace:packages/client"
   dependencies:
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/provider": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/provider": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
     "@node-dlc/messaging": 0.19.1
     "@node-lightning/bitcoin": 0.26.1
     "@types/lodash": ^4.14.160
@@ -194,7 +194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/crypto@^3.0.0, @atomicfinance/crypto@workspace:packages/crypto":
+"@atomicfinance/crypto@^3.0.1, @atomicfinance/crypto@workspace:packages/crypto":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/crypto@workspace:packages/crypto"
   dependencies:
@@ -206,7 +206,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/errors@^3.0.0, @atomicfinance/errors@workspace:packages/errors":
+"@atomicfinance/errors@^3.0.1, @atomicfinance/errors@workspace:packages/errors":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/errors@workspace:packages/errors"
   dependencies:
@@ -215,12 +215,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/jsonrpc-provider@^3.0.0, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
+"@atomicfinance/jsonrpc-provider@^3.0.1, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/node-provider": ^3.0.0
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/node-provider": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/json-bigint": ^1.0.0
     "@types/lodash": ^4.14.168
@@ -229,12 +229,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/node-provider@^3.0.0, @atomicfinance/node-provider@workspace:packages/node-provider":
+"@atomicfinance/node-provider@^3.0.1, @atomicfinance/node-provider@workspace:packages/node-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/node-provider@workspace:packages/node-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/provider": ^3.0.0
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/provider": ^3.0.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     axios: ^0.21.0
@@ -242,18 +242,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/provider@^3.0.0, @atomicfinance/provider@workspace:packages/provider":
+"@atomicfinance/provider@^3.0.1, @atomicfinance/provider@workspace:packages/provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/provider@workspace:packages/provider"
   dependencies:
-    "@atomicfinance/types": ^3.0.0
+    "@atomicfinance/types": ^3.0.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/types@^3.0.0, @atomicfinance/types@workspace:packages/types":
+"@atomicfinance/types@^3.0.1, @atomicfinance/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/types@workspace:packages/types"
   dependencies:
@@ -266,18 +266,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/utils@^3.0.0, @atomicfinance/utils@workspace:packages/utils":
+"@atomicfinance/utils@^3.0.1, @atomicfinance/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/utils@workspace:packages/utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.0.0
-    "@atomicfinance/errors": ^3.0.0
-    "@atomicfinance/types": ^3.0.0
+    "@atomicfinance/crypto": ^3.0.1
+    "@atomicfinance/errors": ^3.0.1
+    "@atomicfinance/types": ^3.0.1
     "@babel/runtime": ^7.12.1
     bignumber.js: ^9.0.0
     bip174: ^2.0.1
     bitcoin-networks: ^1.0.0
-    bitcoinjs-lib: ^5.2.0
+    bitcoinjs-lib: 5.2.0
     coinselect: ^3.1.11
     lodash: ^4.17.20
     setimmediate: ^1.0.5
@@ -3681,7 +3681,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bitcoinjs-lib@npm:5.2.0, bitcoinjs-lib@npm:^5.2.0":
+"bitcoinjs-lib@npm:5.2.0":
   version: 5.2.0
   resolution: "bitcoinjs-lib@npm:5.2.0"
   dependencies:


### PR DESCRIPTION
## What

Fix unit in custom oracle tests

There are two tests affected

`Custom Strategy Oracle POC numdigits=18` and `Custom Strategy Oracle POC numdigits=21`

numdigits = 18 original:
```ts
  const { payoutFunction } = LinearPayout.buildPayoutFunction(
    80000000n,
    120000000n,
    80000n,
    120000n,
    oracleBase,
    numDigits,
  );
  ...
  const unit = 'Bits';
```

Representing `minPayout = 80000000n, maxPayout = 120000000n, startOutcome = 80000n, endOutcome = 120000n`

`minPayout` is in sats, so that's 0.8 BTC (`80,000,000 / 1e8`)

According to https://en.bitcoin.it/wiki/Units `micro-bitcoin` or `bit` is `0.000001`

`0.000001 * 1e6 = 1 bit`

Therefore

`0.8 * 1e6 = 800,000 bits` 

However in the example, `startOutcome` is `80,000 bits` which is incorrect

On the other hand 👇 

numdigits = 21 original:
```ts
const { payoutFunction } = LinearPayout.buildPayoutFunction(
    80000000n,
    104000000n,
    800000n,
    1040000n,
    oracleBase,
    numDigits,
  );
  ...
  const unit = 'Bits * 10^-1';
```

Represents `minPayout = 80000000n, maxPayout = 120000000n, startOutcome = 800000n, endOutcome = 1200000n`

However this is backward, since `800000 / 1e5 = 8`

Therefore the unit of each of these tests needs to be switched

