### PR TITLE
✨ feat: custom starting address index js wallet

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "test": "yarn run test:unit && yarn run test:integration",
     "test:unit": "turbo run test",
     "test:integration": "nyc --reporter=text --reporter=lcov cross-env NODE_ENV=test mocha --parallel",
+    "test:integration:single": "nyc --reporter=text --reporter=lcov cross-env NODE_ENV=test mocha",
     "prepublishOnly": "yarn build",
     "changeset": "changeset",
     "version": "yarn changeset version",

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -38,6 +38,7 @@ interface BitcoinJsWalletProviderOptions {
   mnemonic: string;
   baseDerivationPath: string;
   addressType?: bT.AddressType;
+  addressIndex?: number;
 }
 
 export default class BitcoinJsWalletProvider extends BitcoinWalletProvider(
@@ -53,8 +54,9 @@ export default class BitcoinJsWalletProvider extends BitcoinWalletProvider(
       mnemonic,
       baseDerivationPath,
       addressType = bT.AddressType.BECH32,
+      addressIndex = 0,
     } = options;
-    super({ network, baseDerivationPath, addressType });
+    super({ network, baseDerivationPath, addressType, addressIndex });
 
     if (!mnemonic) throw new Error('Mnemonic should not be empty');
 

--- a/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.ts
+++ b/packages/bitcoin-wallet-provider/lib/BitcoinWalletProvider.ts
@@ -44,6 +44,7 @@ interface BitcoinWalletProviderOptions {
   network: BitcoinNetwork;
   baseDerivationPath: string;
   addressType?: bT.AddressType;
+  addressIndex?: number;
 }
 
 export default <T extends Constructor<Provider>>(superclass: T) => {
@@ -55,6 +56,7 @@ export default <T extends Constructor<Provider>>(superclass: T) => {
     _maxAddressesToDerive: number;
     _baseDerivationPath: string;
     _addressType: bT.AddressType;
+    _addressIndex: number;
     _derivationCache: DerivationCache;
 
     constructor(...args: any[]) {
@@ -63,6 +65,7 @@ export default <T extends Constructor<Provider>>(superclass: T) => {
         network,
         baseDerivationPath,
         addressType = bT.AddressType.BECH32,
+        addressIndex = 0,
       } = options;
       const addressTypes = Object.values(bT.AddressType);
       if (!addressTypes.includes(addressType)) {
@@ -74,6 +77,7 @@ export default <T extends Constructor<Provider>>(superclass: T) => {
       this._baseDerivationPath = baseDerivationPath;
       this._network = network;
       this._addressType = addressType;
+      this._addressIndex = addressIndex;
       this._derivationCache = {};
       this._unusedAddressesBlacklist = {};
       this._maxAddressesToDerive = 5000;
@@ -282,7 +286,7 @@ export default <T extends Constructor<Provider>>(superclass: T) => {
       const unusedAddressMap = { change: null, nonChange: null };
 
       let addrList;
-      let addressIndex = 0;
+      let addressIndex = this._addressIndex;
       let changeAddresses: Address[] = [];
       let nonChangeAddresses: Address[] = [];
 

--- a/tests/integration/wallet/wallet.test.ts
+++ b/tests/integration/wallet/wallet.test.ts
@@ -16,8 +16,8 @@ import * as fixtures from '../fixtures/wallet.json';
 
 const chain = chains.bitcoinWithJs;
 const alice = chain.client;
-
 const bob = chains.bitcoinWithJs2.client;
+const frank = chains.bitcoinWithJs5.client; // custom starting addressIndex provided
 
 describe('wallet provider', () => {
   describe('getUnusedAddress', () => {
@@ -34,6 +34,13 @@ describe('wallet provider', () => {
       const blacklist = await bob.getMethod('getUnusedAddressesBlacklist')();
       const n = Object.keys(blacklist).length - 1;
       expect(Object.keys(blacklist)[n]).to.equal(unusedAddress.address);
+    });
+  });
+
+  describe('getAddress with addressIndex', () => {
+    it('should get address at custom derivation path', async () => {
+      const unusedAddress = await frank.wallet.getUnusedAddress();
+      expect(unusedAddress.derivationPath).to.equal("m/84'/1'/0'/0/100");
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-cfd-provider@workspace:packages/bitcoin-cfd-provider"
   dependencies:
-    "@atomicfinance/provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
@@ -32,10 +32,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-dlc-provider@workspace:packages/bitcoin-dlc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": 3.2.0
-    "@atomicfinance/provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-utils": 3.2.1
+    "@atomicfinance/provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@node-dlc/core": 0.21.2
     "@node-dlc/messaging": 0.21.2
     "@node-lightning/bitcoin": 0.26.1
@@ -53,16 +53,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-esplora-api-provider@^3.2.0, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
+"@atomicfinance/bitcoin-esplora-api-provider@^3.2.1, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.0
-    "@atomicfinance/crypto": ^3.2.0
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/node-provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-utils": ^3.2.1
+    "@atomicfinance/crypto": ^3.2.1
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/node-provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -76,10 +76,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-batch-api-provider@workspace:packages/bitcoin-esplora-batch-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-esplora-api-provider": ^3.2.0
-    "@atomicfinance/node-provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-esplora-api-provider": ^3.2.1
+    "@atomicfinance/node-provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -92,10 +92,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-js-wallet-provider@workspace:packages/bitcoin-js-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.0
-    "@atomicfinance/bitcoin-wallet-provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-utils": ^3.2.1
+    "@atomicfinance/bitcoin-wallet-provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     bip32: ^2.0.6
     bip39: ^3.0.2
@@ -110,11 +110,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-node-wallet-provider@workspace:packages/bitcoin-node-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.0
-    "@atomicfinance/crypto": ^3.2.0
-    "@atomicfinance/jsonrpc-provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-utils": ^3.2.1
+    "@atomicfinance/crypto": ^3.2.1
+    "@atomicfinance/jsonrpc-provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -128,11 +128,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-rpc-provider@workspace:packages/bitcoin-rpc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.0
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/jsonrpc-provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/bitcoin-utils": ^3.2.1
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/jsonrpc-provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -141,14 +141,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-utils@3.2.0, @atomicfinance/bitcoin-utils@^3.2.0, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
+"@atomicfinance/bitcoin-utils@3.2.1, @atomicfinance/bitcoin-utils@^3.2.1, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.2.0
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
-    "@atomicfinance/utils": ^3.2.0
+    "@atomicfinance/crypto": ^3.2.1
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
+    "@atomicfinance/utils": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/bitcoinjs-lib": ^5.0.0
     "@types/lodash": ^4.14.168
@@ -162,13 +162,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-wallet-provider@^3.2.0, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
+"@atomicfinance/bitcoin-wallet-provider@^3.2.1, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.0
-    "@atomicfinance/provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
+    "@atomicfinance/bitcoin-utils": ^3.2.1
+    "@atomicfinance/provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     bitcoin-networks: ^1.0.0
@@ -182,9 +182,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/client@workspace:packages/client"
   dependencies:
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/provider": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/provider": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
     "@node-dlc/messaging": 0.21.2
     "@node-lightning/bitcoin": 0.26.1
     "@types/lodash": ^4.14.160
@@ -194,7 +194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/crypto@^3.2.0, @atomicfinance/crypto@workspace:packages/crypto":
+"@atomicfinance/crypto@^3.2.1, @atomicfinance/crypto@workspace:packages/crypto":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/crypto@workspace:packages/crypto"
   dependencies:
@@ -206,7 +206,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/errors@^3.2.0, @atomicfinance/errors@workspace:packages/errors":
+"@atomicfinance/errors@^3.2.1, @atomicfinance/errors@workspace:packages/errors":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/errors@workspace:packages/errors"
   dependencies:
@@ -215,12 +215,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/jsonrpc-provider@^3.2.0, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
+"@atomicfinance/jsonrpc-provider@^3.2.1, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/node-provider": ^3.2.0
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/node-provider": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/json-bigint": ^1.0.0
     "@types/lodash": ^4.14.168
@@ -229,12 +229,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/node-provider@^3.2.0, @atomicfinance/node-provider@workspace:packages/node-provider":
+"@atomicfinance/node-provider@^3.2.1, @atomicfinance/node-provider@workspace:packages/node-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/node-provider@workspace:packages/node-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/provider": ^3.2.0
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/provider": ^3.2.1
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     axios: ^0.21.0
@@ -242,18 +242,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/provider@^3.2.0, @atomicfinance/provider@workspace:packages/provider":
+"@atomicfinance/provider@^3.2.1, @atomicfinance/provider@workspace:packages/provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/provider@workspace:packages/provider"
   dependencies:
-    "@atomicfinance/types": ^3.2.0
+    "@atomicfinance/types": ^3.2.1
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/types@^3.2.0, @atomicfinance/types@workspace:packages/types":
+"@atomicfinance/types@^3.2.1, @atomicfinance/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/types@workspace:packages/types"
   dependencies:
@@ -266,13 +266,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/utils@^3.2.0, @atomicfinance/utils@workspace:packages/utils":
+"@atomicfinance/utils@^3.2.1, @atomicfinance/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/utils@workspace:packages/utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.2.0
-    "@atomicfinance/errors": ^3.2.0
-    "@atomicfinance/types": ^3.2.0
+    "@atomicfinance/crypto": ^3.2.1
+    "@atomicfinance/errors": ^3.2.1
+    "@atomicfinance/types": ^3.2.1
     "@babel/runtime": ^7.12.1
     bignumber.js: ^9.0.0
     bip174: ^2.0.1


### PR DESCRIPTION
## What

Add custom starting `addressIndex` for js wallet provider

This allows `getUsedAddress` and `getUnusedAddress` to start searching for addresses at a certain `addressIndex`

## Why

After a wallet becomes significantly used, to speed up queries, the `startingIndex` should be incremented to whatever index is deemed safe. 