### PR TITLE
🐛 fix: find outcome index hyperbola edge case

### DIFF
--- a/.changeset/good-lies-float.md
+++ b/.changeset/good-lies-float.md
@@ -1,0 +1,21 @@
+---
+'@atomicfinance/bitcoin-dlc-provider': minor
+'@atomicfinance/bitcoin-cfd-provider': minor
+'@atomicfinance/bitcoin-esplora-api-provider': minor
+'@atomicfinance/bitcoin-esplora-batch-api-provider': minor
+'@atomicfinance/bitcoin-js-wallet-provider': minor
+'@atomicfinance/bitcoin-node-wallet-provider': minor
+'@atomicfinance/bitcoin-rpc-provider': minor
+'@atomicfinance/bitcoin-utils': minor
+'@atomicfinance/bitcoin-wallet-provider': minor
+'@atomicfinance/client': minor
+'@atomicfinance/crypto': minor
+'@atomicfinance/errors': minor
+'@atomicfinance/jsonrpc-provider': minor
+'@atomicfinance/node-provider': minor
+'@atomicfinance/provider': minor
+'@atomicfinance/types': minor
+'@atomicfinance/utils': minor
+---
+
+Fix find outcome index for hyperbola payout curve edge case

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,9 +19,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-cfd-provider@workspace:packages/bitcoin-cfd-provider"
   dependencies:
-    "@atomicfinance/provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
@@ -32,10 +32,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-dlc-provider@workspace:packages/bitcoin-dlc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": 3.2.4
-    "@atomicfinance/provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-utils": 3.2.5
+    "@atomicfinance/provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@node-dlc/core": 0.22.4
     "@node-dlc/messaging": 0.22.4
     "@node-lightning/bitcoin": 0.26.1
@@ -53,16 +53,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-esplora-api-provider@^3.2.4, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
+"@atomicfinance/bitcoin-esplora-api-provider@^3.2.5, @atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-api-provider@workspace:packages/bitcoin-esplora-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.4
-    "@atomicfinance/crypto": ^3.2.4
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/node-provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-utils": ^3.2.5
+    "@atomicfinance/crypto": ^3.2.5
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/node-provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -76,10 +76,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-esplora-batch-api-provider@workspace:packages/bitcoin-esplora-batch-api-provider"
   dependencies:
-    "@atomicfinance/bitcoin-esplora-api-provider": ^3.2.4
-    "@atomicfinance/node-provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-esplora-api-provider": ^3.2.5
+    "@atomicfinance/node-provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -92,10 +92,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-js-wallet-provider@workspace:packages/bitcoin-js-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.4
-    "@atomicfinance/bitcoin-wallet-provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-utils": ^3.2.5
+    "@atomicfinance/bitcoin-wallet-provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     bip32: ^2.0.6
     bip39: ^3.0.2
@@ -110,11 +110,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-node-wallet-provider@workspace:packages/bitcoin-node-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.4
-    "@atomicfinance/crypto": ^3.2.4
-    "@atomicfinance/jsonrpc-provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-utils": ^3.2.5
+    "@atomicfinance/crypto": ^3.2.5
+    "@atomicfinance/jsonrpc-provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -128,11 +128,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-rpc-provider@workspace:packages/bitcoin-rpc-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.4
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/jsonrpc-provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/bitcoin-utils": ^3.2.5
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/jsonrpc-provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     bignumber.js: ^9.0.0
@@ -141,14 +141,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-utils@3.2.4, @atomicfinance/bitcoin-utils@^3.2.4, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
+"@atomicfinance/bitcoin-utils@3.2.5, @atomicfinance/bitcoin-utils@^3.2.5, @atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-utils@workspace:packages/bitcoin-utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.2.4
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
-    "@atomicfinance/utils": ^3.2.4
+    "@atomicfinance/crypto": ^3.2.5
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
+    "@atomicfinance/utils": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/bitcoinjs-lib": ^5.0.0
     "@types/lodash": ^4.14.168
@@ -162,13 +162,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/bitcoin-wallet-provider@^3.2.4, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
+"@atomicfinance/bitcoin-wallet-provider@^3.2.5, @atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/bitcoin-wallet-provider@workspace:packages/bitcoin-wallet-provider"
   dependencies:
-    "@atomicfinance/bitcoin-utils": ^3.2.4
-    "@atomicfinance/provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
+    "@atomicfinance/bitcoin-utils": ^3.2.5
+    "@atomicfinance/provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     bitcoin-networks: ^1.0.0
@@ -182,9 +182,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atomicfinance/client@workspace:packages/client"
   dependencies:
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/provider": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/provider": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
     "@node-dlc/messaging": 0.22.4
     "@node-lightning/bitcoin": 0.26.1
     "@types/lodash": ^4.14.160
@@ -194,7 +194,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/crypto@^3.2.4, @atomicfinance/crypto@workspace:packages/crypto":
+"@atomicfinance/crypto@^3.2.5, @atomicfinance/crypto@workspace:packages/crypto":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/crypto@workspace:packages/crypto"
   dependencies:
@@ -206,7 +206,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/errors@^3.2.4, @atomicfinance/errors@workspace:packages/errors":
+"@atomicfinance/errors@^3.2.5, @atomicfinance/errors@workspace:packages/errors":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/errors@workspace:packages/errors"
   dependencies:
@@ -215,12 +215,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/jsonrpc-provider@^3.2.4, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
+"@atomicfinance/jsonrpc-provider@^3.2.5, @atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/jsonrpc-provider@workspace:packages/jsonrpc-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/node-provider": ^3.2.4
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/node-provider": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/json-bigint": ^1.0.0
     "@types/lodash": ^4.14.168
@@ -229,12 +229,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/node-provider@^3.2.4, @atomicfinance/node-provider@workspace:packages/node-provider":
+"@atomicfinance/node-provider@^3.2.5, @atomicfinance/node-provider@workspace:packages/node-provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/node-provider@workspace:packages/node-provider"
   dependencies:
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/provider": ^3.2.4
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/provider": ^3.2.5
     "@babel/runtime": ^7.12.1
     "@types/lodash": ^4.14.168
     axios: ^0.21.0
@@ -242,18 +242,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/provider@^3.2.4, @atomicfinance/provider@workspace:packages/provider":
+"@atomicfinance/provider@^3.2.5, @atomicfinance/provider@workspace:packages/provider":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/provider@workspace:packages/provider"
   dependencies:
-    "@atomicfinance/types": ^3.2.4
+    "@atomicfinance/types": ^3.2.5
     "@types/lodash": ^4.14.160
     "@types/node": 16.10.3
     lodash: ^4.17.20
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/types@^3.2.4, @atomicfinance/types@workspace:packages/types":
+"@atomicfinance/types@^3.2.5, @atomicfinance/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/types@workspace:packages/types"
   dependencies:
@@ -266,13 +266,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atomicfinance/utils@^3.2.4, @atomicfinance/utils@workspace:packages/utils":
+"@atomicfinance/utils@^3.2.5, @atomicfinance/utils@workspace:packages/utils":
   version: 0.0.0-use.local
   resolution: "@atomicfinance/utils@workspace:packages/utils"
   dependencies:
-    "@atomicfinance/crypto": ^3.2.4
-    "@atomicfinance/errors": ^3.2.4
-    "@atomicfinance/types": ^3.2.4
+    "@atomicfinance/crypto": ^3.2.5
+    "@atomicfinance/errors": ^3.2.5
+    "@atomicfinance/types": ^3.2.5
     "@babel/runtime": ^7.12.1
     bignumber.js: ^9.0.0
     bip174: ^2.0.1


### PR DESCRIPTION
## What

Fix find outcome index hyperbola edge case

## Context

In certain cases, the `roundedPayout` in `FindOutcomeIndexFromHyperbolaPayoutCurvePiece` does not equal the larger payout value in the payoutGroups

In this case, when searching for the appropriate group index, you shoudl check if the `payoutGroup.payout` equals the `roundedPayout` and also check if it equals the `payout` from `clampBN(hyperbolaCurve.getPayout(outcome));` and update the returned `index` accordingly

This will ensure the right `index` and right CET signature is found when executing the DLC