### PR TITLE
fix: types with bitcoin-rpc-provider

### DIFF
--- a/.changeset/tiny-pumpkins-trade.md
+++ b/.changeset/tiny-pumpkins-trade.md
@@ -1,0 +1,21 @@
+---
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Fix types for bitcoin-rpc-provider

--- a/packages/bitcoin-rpc-provider/package.json
+++ b/packages/bitcoin-rpc-provider/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "module": "dist/index.js",
   "main": "dist/index.js",
-  "types": "dist/lib/index.d.ts",
   "directories": {
     "dist": "dist",
     "src": "lib"


### PR DESCRIPTION
## What

Fix the types issues with bitcoin-rpc-provider

## Why

It was looking for types in the wrong directory. Removes the incorrect line associated with this