### PR TITLE
feat: add enum support to dlc provider

### DIFF
--- a/.changeset/gold-ducks-clean.md
+++ b/.changeset/gold-ducks-clean.md
@@ -1,0 +1,21 @@
+---
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Add support for Enum DLCs

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "test": "yarn run test:unit",
     "test:unit": "turbo run test",
     "test:integration": "nyc --reporter=text --reporter=lcov cross-env NODE_ENV=test mocha --parallel --max-old-space-size=4096",
-    "test:integration:sequential": "nyc --reporter=text --reporter=lcov cross-env NODE_ENV=test mocha --max-old-space-size=4096 --verbose --timeout 60000",
+    "test:integration:sequential": "nyc --reporter=text --reporter=lcov cross-env NODE_ENV=test mocha --max-old-space-size=4096 --timeout 60000",
     "prepublishOnly": "yarn build",
     "changeset": "changeset",
     "version": "yarn changeset version",

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -235,7 +235,6 @@ async function getInput(
     maxWitnessLength: 108,
     redeemScript: '',
     toUtxo: Input.prototype.toUtxo,
-    toOutPoint: Input.prototype.toOutPoint,
   };
 
   return input;

--- a/tests/integration/config.ts
+++ b/tests/integration/config.ts
@@ -8,8 +8,8 @@ export default {
   bitcoin: {
     rpc: {
       host: 'http://localhost:18443',
-      username: process.env.RPC_USER || 'bitcoin',
-      password: process.env.RPC_PASS || 'local321',
+      username: process.env.RPC_USER || 'admin1',
+      password: process.env.RPC_PASS || '123',
     },
     network: BitcoinNetworks.bitcoin_regtest,
     value: 1000000,

--- a/tests/integration/dlc/custom-oracle.test.ts
+++ b/tests/integration/dlc/custom-oracle.test.ts
@@ -464,6 +464,8 @@ describe('Custom Strategy Oracle POC numdigits=21', () => {
         fees,
       );
 
+      console.time('offer');
+
       dlcOffer = await alice.dlc.createDlcOffer(
         offerFinalized.contractInfo,
         offerFinalized.offerCollateralSatoshis,

--- a/tests/integration/models/Oracle.ts
+++ b/tests/integration/models/Oracle.ts
@@ -1,6 +1,7 @@
 import * as cfdjs from 'cfd-js';
-import * as CfdUtils from '../utils/Utils';
+
 import OracleInfo from '../../../packages/types/lib/models/OracleInfo';
+import * as CfdUtils from '../utils/Utils';
 
 export default class Oracle {
   readonly name: string;


### PR DESCRIPTION
## What

Add enum support to `BitcoinDlcProvider` 

Specifically, it adds support for the creation of simple binary options (trump won or kamala won) into the existing `createDlcOffer`, `acceptDlcOffer`, `signDlcAccept`, `finalizeDlcSign`, and `execute` functions in `BitcoinDlcProvider`
