### PR TITLE
fix: enum hashed outcomes

### DIFF
--- a/.changeset/grumpy-toes-accept.md
+++ b/.changeset/grumpy-toes-accept.md
@@ -1,0 +1,21 @@
+---
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Fix enum hashed outcomes

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -599,7 +599,7 @@ export default class BitcoinDlcProvider
             dlcAccept.acceptCollateralSatoshis -
             outcome.localPayout,
         });
-        messagesList.push({ messages: [outcome.outcome.toString()] });
+        messagesList.push({ messages: [outcome.outcome.toString('hex')] });
       }
     } else {
       const payoutResponses = this.GetPayouts(dlcOffer);
@@ -1731,8 +1731,8 @@ Payout Group not found',
       const outcomeIndex = ((dlcOffer.contractInfo as ContractInfoV0)
         .contractDescriptor as ContractDescriptorV0).outcomes.findIndex(
         (outcome) =>
-          outcome.outcome.toString() ===
-          oracleAttestation.outcomes[0].toString(),
+          outcome.outcome.toString('hex') ===
+          sha256(Buffer.from(oracleAttestation.outcomes[0])).toString('hex'),
       );
 
       signCetRequest = {
@@ -2877,7 +2877,7 @@ Payout Group not found',
     ) {
       for (const outcome of ((dlcOffer.contractInfo as ContractInfoV0)
         .contractDescriptor as ContractDescriptorV0).outcomes) {
-        messagesList.push({ messages: [outcome.outcome.toString()] });
+        messagesList.push({ messages: [outcome.outcome.toString('hex')] });
       }
     } else {
       const payoutResponses = this.GetPayouts(dlcOffer);

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -31,7 +31,7 @@ import {
   OracleInfoV0,
   RoundingIntervalsV0,
 } from '@node-dlc/messaging';
-import { xor } from '@node-lightning/crypto';
+import { sha256, xor } from '@node-lightning/crypto';
 import BN from 'bignumber.js';
 import { math } from 'bip-schnorr';
 import { BitcoinNetworks, chainHashFromNetwork } from 'bitcoin-networks';
@@ -185,15 +185,15 @@ describe('dlc provider', () => {
 
       contractDescriptor.outcomes = [
         {
-          outcome: Buffer.from('trump', 'utf8'),
+          outcome: sha256(Buffer.from('trump')),
           localPayout: BigInt(1e6),
         },
         {
-          outcome: Buffer.from('kamala', 'utf8'),
+          outcome: sha256(Buffer.from('kamala')),
           localPayout: BigInt(0),
         },
         {
-          outcome: Buffer.from('neither', 'utf8'),
+          outcome: sha256(Buffer.from('neither')),
           localPayout: BigInt(500000),
         },
       ];
@@ -217,6 +217,9 @@ describe('dlc provider', () => {
         refundLocktime,
         [aliceInput],
       );
+
+      const dlcOfferV0 = DlcOfferV0.deserialize(dlcOffer.serialize());
+      dlcOfferV0.validate();
 
       const acceptDlcOfferResponse: AcceptDlcOfferResponse = await bob.dlc.acceptDlcOffer(
         dlcOffer,

--- a/tests/integration/utils/contract.ts
+++ b/tests/integration/utils/contract.ts
@@ -20,6 +20,7 @@ import {
   PayoutFunctionV0,
   RoundingIntervalsV0,
 } from '@node-dlc/messaging';
+import { sha256 } from '@node-lightning/crypto';
 import BN from 'bignumber.js';
 import { math } from 'bip-schnorr';
 
@@ -307,7 +308,10 @@ export function generateEnumOracleAttestation(
   const sigs: Buffer[] = [];
 
   const m = math
-    .taggedHash('DLC/oracle/attestation/v0', outcome)
+    .taggedHash(
+      'DLC/oracle/attestation/v0',
+      sha256(Buffer.from(outcome)).toString('hex'),
+    )
     .toString('hex');
   sigs.push(Buffer.from(oracle.GetSignature(m), 'hex'));
 


### PR DESCRIPTION
## What

Fix enum hashed outcomes

Outcome needs to be 32 bytes, according to `ContractDescriptorV0`

https://github.com/AtomicFinance/node-dlc/blob/master/packages/messaging/lib/messages/ContractDescriptor.ts#L64

Therefore, outcome needs to be hashed, when checking oracleAnnouncement vs attestation and when signing with the oracle