### PR TITLE
refactor: Organize imports in BitcoinDlcProvider

### DIFF
--- a/.changeset/empty-news-share.md
+++ b/.changeset/empty-news-share.md
@@ -1,0 +1,21 @@
+---
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Update import modules organize imports

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -28,6 +28,7 @@ import {
   CreateSignatureHashRequest,
   CreateSplicedDlcTransactionsRequest,
   CreateSplicedDlcTransactionsResponse,
+  DlcInputInfo,
   DlcInputInfoRequest,
   DlcProvider,
   GetRawDlcFundingInputSignatureRequest,
@@ -37,6 +38,7 @@ import {
   GetRawRefundTxSignatureRequest,
   GetRawRefundTxSignatureResponse,
   Input,
+  InputSupplementationMode,
   Messages,
   PayoutRequest,
   SignCetRequest,
@@ -58,10 +60,6 @@ import {
   VerifyRefundTxSignatureResponse,
   VerifySignatureRequest,
 } from '@atomicfinance/types';
-import {
-  DlcInputInfo,
-  InputSupplementationMode,
-} from '@atomicfinance/types/lib/models/Input';
 import { sleep } from '@atomicfinance/utils';
 import { Script, Sequence, Tx } from '@node-dlc/bitcoin';
 import { StreamReader } from '@node-dlc/bufio';


### PR DESCRIPTION
## Problem
The `BitcoinDlcProvider` was importing `DlcInputInfo` and `InputSupplementationMode` from a specific internal model file path (`@atomicfinance/types/lib/models/Input`) instead of using the main package export.

## Solution
- Move `DlcInputInfo` and `InputSupplementationMode` to the main `@atomicfinance/types` import block
- Remove the separate import from the internal model file path
- Maintain alphabetical ordering in the import list

## Benefits
- **Consistent import style**: All types now imported from the main package export
- **Better encapsulation**: Uses public API instead of reaching into internal file structure
- **Improved maintainability**: Changes to internal file structure won't break imports
- **Cleaner code**: Consolidated imports in a single location

## Testing
- [x] No functional changes - purely organizational
- [x] Types are properly exported from main package index
- [x] No breaking changes to public API

This is a non-breaking refactor that improves code organization and follows TypeScript/JavaScript best practices for package imports.