### PR TITLE
feat: implement rust-dlc compatible contract ID computation

### DIFF
--- a/.changeset/tasty-sides-enjoy.md
+++ b/.changeset/tasty-sides-enjoy.md
@@ -1,0 +1,24 @@
+---
+'@atomicfinance/bitcoin-ddk-provider': patch
+'@atomicfinance/bitcoin-cfd-address-derivation-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-ddk-address-derivation-provider': patch
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Implement rust-dlc/ddk compatible Contract ID computation

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -272,6 +272,31 @@ describe('dlc provider', () => {
       const cetTx = await alice.getMethod('getTransactionByHash')(cetTxId);
       expect(cetTx._raw.vin.length).to.equal(1);
     });
+
+    describe('ddk provider contract id computation', () => {
+      it('should compute contract ID matching Rust implementation', async () => {
+        // Test data from Rust test case
+        const fundTxHex =
+          '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff020000ffffffff0101000000000000000000000000';
+        const outputIndex = 1;
+        const temporaryId = Buffer.alloc(32, 34); // [34u8; 32]
+        const expectedId =
+          '81db60dcbef10a2d0cb92cb78400a96ee6a9b6da785d0230bdabf1e18a2d6ffb';
+
+        // Parse the transaction and get the txid
+        const fundTx = Tx.decode(StreamReader.fromHex(fundTxHex));
+        const fundTxId = fundTx.txId.serialize();
+
+        // Use DDK provider to test the computeContractId function
+        const actualId = ddk.getMethod('computeContractId')(
+          fundTxId,
+          outputIndex,
+          temporaryId,
+        );
+
+        expect(actualId.toString('hex')).to.equal(expectedId);
+      });
+    });
   });
 
   describe('enum event', () => {


### PR DESCRIPTION
## Summary
Implements proper contract ID computation that matches the rust-dlc/ddk implementation, replacing the previous simple XOR approach

## Changes
- **Added `computeContractId` method** that properly computes contract IDs according to the DLC specification
- **Includes fund output index** in the calculation (was previously missing)
- **Implements byte order reversal** for the fund transaction ID as required by the spec
- **Replaces simple XOR operations** with the proper contract ID computation in both DLC accept and sign flows
- **Adds comprehensive test case** using the same test vectors as the Rust implementation
- **Removes unused import** of `xor` function

## Technical Details
The new implementation follows the exact same logic as rust-dlc's `compute_id` function:
1. XORs fund transaction ID (with byte order reversal) with temporary contract ID
2. XORs the fund output index into the last two bytes of the result
3. Returns a proper 32-byte contract ID

## Testing
Added test case that validates the implementation against the exact same test data used in the rust-dlc/ddk test suite

## Breaking Changes
None - this is an internal implementation detail that doesn't affect the public API.

## Fixes
Ensures contract ID generation is compatible with other DLC implementations that follow the rust-dlc specification.