### PR TITLE
fix: replace DDK-based refund signatures with PSBT method for compatibility

### DIFF
--- a/.changeset/better-animals-beam.md
+++ b/.changeset/better-animals-beam.md
@@ -1,0 +1,24 @@
+---
+'@atomicfinance/bitcoin-ddk-provider': patch
+'@atomicfinance/bitcoin-cfd-address-derivation-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-ddk-address-derivation-provider': patch
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Fix refund sig generation bitcoin ddk provider

--- a/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
+++ b/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
@@ -320,6 +320,94 @@ export default class BitcoinDdkProvider extends Provider {
   }
 
   /**
+   * Create refund signature using PSBT method instead of DDK
+   */
+  private async createRefundSignaturePSBT(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTxs: DlcTransactions,
+    isOfferer: boolean,
+  ): Promise<Buffer> {
+    const network = await this.getConnectedNetwork();
+    const psbt = new Psbt({ network });
+
+    // Verify refund transaction locktime matches expected
+    if (Number(dlcTxs.refundTx.locktime) !== dlcOffer.refundLocktime) {
+      throw new Error(
+        `Refund transaction locktime ${dlcTxs.refundTx.locktime} does not match expected ${dlcOffer.refundLocktime}`,
+      );
+    }
+
+    // Create the same funding script as createDlcClose
+    const fundingPubKeys =
+      Buffer.compare(dlcOffer.fundingPubkey, dlcAccept.fundingPubkey) === -1
+        ? [dlcOffer.fundingPubkey, dlcAccept.fundingPubkey]
+        : [dlcAccept.fundingPubkey, dlcOffer.fundingPubkey];
+
+    const p2ms = payments.p2ms({
+      m: 2,
+      pubkeys: fundingPubKeys,
+      network,
+    });
+
+    const paymentVariant = payments.p2wsh({
+      redeem: p2ms,
+      network,
+    });
+
+    // Add the funding input
+    psbt.addInput({
+      hash: dlcTxs.fundTx.txId.serialize(),
+      index: dlcTxs.fundTxVout,
+      sequence: 0,
+      witnessUtxo: {
+        script: paymentVariant.output,
+        value: Number(this.getFundOutputValueSats(dlcTxs)),
+      },
+      witnessScript: paymentVariant.redeem.output,
+    });
+
+    // Add the refund outputs - refund transaction should have 2 outputs (offerer and accepter)
+    dlcTxs.refundTx.outputs.forEach((refundOutput) => {
+      psbt.addOutput({
+        address: address.fromOutputScript(
+          refundOutput.scriptPubKey.serialize().subarray(1),
+          network,
+        ),
+        value: Number(refundOutput.value.sats),
+      });
+    });
+
+    // Set the locktime to match the refund transaction
+    psbt.setLocktime(Number(dlcTxs.refundTx.locktime));
+
+    // Generate our keypair to sign the refund input
+    const fundPrivateKeyPair = await this.GetFundKeyPair(
+      dlcOffer,
+      dlcAccept,
+      isOfferer,
+    );
+
+    // Sign the input
+    psbt.signInput(0, fundPrivateKeyPair);
+
+    // Validate the signature
+    psbt.validateSignaturesOfInput(
+      0,
+      (pubkey: Buffer, msghash: Buffer, signature: Buffer) => {
+        return ecc.verify(msghash, pubkey, signature);
+      },
+    );
+
+    // Extract our signature and decode it to only extract r and s values (compact format)
+    const partialSig = psbt.data.inputs[0].partialSig[0];
+    const derSignature = partialSig.signature;
+
+    // Convert DER signature to compact format
+    return this.ensureCompactSignature(derSignature);
+  }
+
+  /**
    * Find private key for DLC funding pubkey by deriving wallet addresses
    */
   private async findDlcFundingPrivateKey(
@@ -1355,14 +1443,11 @@ export default class BitcoinDdkProvider extends Provider {
       }
     }
 
-    const refundSignature = this.ensureCompactSignature(
-      this._ddk.getRawFundingTransactionInputSignature(
-        this.convertTxToDdkTransaction(dlcTxs.refundTx),
-        Buffer.from(fundPrivateKey, 'hex'),
-        dlcTxs.fundTx.txId.toString(),
-        dlcTxs.fundTxVout,
-        dlcOffer.contractInfo.totalCollateral,
-      ),
+    const refundSignature = await this.createRefundSignaturePSBT(
+      dlcOffer,
+      dlcAccept,
+      dlcTxs,
+      isOfferer,
     );
 
     const cetSignatures = new CetAdaptorSignatures();
@@ -3477,37 +3562,48 @@ Payout Group not found even with brute force search',
       );
     }
 
-    // Add the funding input
-    const fundingOutput = dlcTxs.fundTx.outputs[dlcTxs.fundTxVout];
-    psbt.addInput({
-      hash: dlcTxs.fundTx.txId.toString(),
-      index: dlcTxs.fundTxVout,
-      sequence: 0,
-      witnessUtxo: {
-        script: fundingOutput.scriptPubKey.serialize().subarray(1), // Remove length prefix
-        value: Number(fundingOutput.value.sats),
-      },
-      witnessScript: this.CreateFundingScript(dlcOffer, dlcAccept), // 2-of-2 multisig script
-    });
-
-    // Add the refund output
-    const refundOutput = dlcTxs.refundTx.outputs[0];
-    psbt.addOutput({
-      address: address.fromOutputScript(
-        refundOutput.scriptPubKey.serialize().subarray(1),
-        network,
-      ),
-      value: Number(refundOutput.value.sats),
-    });
-
-    // Set the locktime to match the refund transaction
-    psbt.setLocktime(Number(dlcTxs.refundTx.locktime));
-
-    // Sort funding pubkeys for consistent signature ordering
+    // Create the same funding script as createDlcClose
     const fundingPubKeys =
       Buffer.compare(dlcOffer.fundingPubkey, dlcAccept.fundingPubkey) === -1
         ? [dlcOffer.fundingPubkey, dlcAccept.fundingPubkey]
         : [dlcAccept.fundingPubkey, dlcOffer.fundingPubkey];
+
+    const p2ms = payments.p2ms({
+      m: 2,
+      pubkeys: fundingPubKeys,
+      network,
+    });
+
+    const paymentVariant = payments.p2wsh({
+      redeem: p2ms,
+      network,
+    });
+
+    // Add the funding input
+    psbt.addInput({
+      hash: dlcTxs.fundTx.txId.serialize(),
+      index: dlcTxs.fundTxVout,
+      sequence: 0,
+      witnessUtxo: {
+        script: paymentVariant.output,
+        value: Number(this.getFundOutputValueSats(dlcTxs)),
+      },
+      witnessScript: paymentVariant.redeem.output,
+    });
+
+    // Add all refund outputs - refund transaction should have 2 outputs (offerer and accepter)
+    dlcTxs.refundTx.outputs.forEach((refundOutput) => {
+      psbt.addOutput({
+        address: address.fromOutputScript(
+          refundOutput.scriptPubKey.serialize().subarray(1),
+          network,
+        ),
+        value: Number(refundOutput.value.sats),
+      });
+    });
+
+    // Set the locktime to match the refund transaction
+    psbt.setLocktime(Number(dlcTxs.refundTx.locktime));
 
     // Add both refund signatures as partial signatures
     // Ensure both signatures are in DER format (convert from compact if needed)

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -273,6 +273,139 @@ describe('dlc provider', () => {
       expect(cetTx._raw.vin.length).to.equal(1);
     });
 
+    it('should fund and refund enum DLC', async () => {
+      const oracle = new Oracle('olivia');
+
+      const ddkInput = await getInput(ddk);
+      const ddk2Input = await getInput(ddk2);
+
+      const eventId = 'trump-vs-kamala';
+
+      const oliviaInfo = oracle.GetOracleInfo();
+
+      const eventDescriptor = new EnumEventDescriptor();
+
+      const outcomes = ['trump', 'kamala', 'neither'];
+
+      eventDescriptor.outcomes = outcomes;
+
+      const event = new OracleEvent();
+      event.oracleNonces = oliviaInfo.rValues.map((rValue) =>
+        Buffer.from(rValue, 'hex'),
+      );
+      event.eventMaturityEpoch = 1617170572;
+      event.eventDescriptor = eventDescriptor;
+      event.eventId = eventId;
+
+      const announcement = new OracleAnnouncement();
+      announcement.announcementSig = Buffer.from(
+        oracle.GetSignature(
+          math
+            .taggedHash('DLC/oracle/announcement/v0', event.serialize())
+            .toString('hex'),
+        ),
+        'hex',
+      );
+
+      announcement.oraclePubkey = Buffer.from(oliviaInfo.publicKey, 'hex');
+      announcement.oracleEvent = event;
+
+      const oracleInfo = new SingleOracleInfo();
+      oracleInfo.announcement = announcement;
+
+      const contractDescriptor = new EnumeratedDescriptor();
+
+      contractDescriptor.outcomes = [
+        {
+          outcome: sha256(Buffer.from('trump')).toString('hex'),
+          localPayout: BigInt(1e6),
+        },
+        {
+          outcome: sha256(Buffer.from('kamala')).toString('hex'),
+          localPayout: BigInt(0),
+        },
+        {
+          outcome: sha256(Buffer.from('neither')).toString('hex'),
+          localPayout: BigInt(500000),
+        },
+      ];
+
+      const totalCollateral = BigInt(1e6);
+
+      const contractInfo = new SingleContractInfo();
+      contractInfo.totalCollateral = totalCollateral;
+      contractInfo.contractDescriptor = contractDescriptor;
+      contractInfo.oracleInfo = oracleInfo;
+
+      const feeRatePerVb = BigInt(10);
+      const cetLocktime = 1617170572;
+      const refundLocktime = 1617170573;
+
+      dlcOffer = await ddk.dlc.createDlcOffer(
+        contractInfo,
+        totalCollateral - BigInt(2000),
+        feeRatePerVb,
+        cetLocktime,
+        refundLocktime,
+        [ddkInput],
+      );
+
+      DlcOffer.deserialize(dlcOffer.serialize()).validate();
+
+      const acceptDlcOfferResponse: AcceptDlcOfferResponse =
+        await ddk2.dlc.acceptDlcOffer(dlcOffer, [ddk2Input]);
+
+      dlcAccept = acceptDlcOfferResponse.dlcAccept;
+      dlcTransactions = acceptDlcOfferResponse.dlcTransactions;
+
+      DlcAccept.deserialize(dlcAccept.serialize()).validate();
+      DlcTransactions.deserialize(dlcTransactions.serialize());
+
+      const signDlcAcceptResponse: SignDlcAcceptResponse =
+        await ddk.dlc.signDlcAccept(dlcOffer, dlcAccept);
+
+      dlcSign = signDlcAcceptResponse.dlcSign;
+
+      DlcSign.deserialize(dlcSign.serialize()).validate();
+
+      const fundTx = await ddk2.dlc.finalizeDlcSign(
+        dlcOffer,
+        dlcAccept,
+        dlcSign,
+        dlcTransactions,
+      );
+
+      const fundTxId = await ddk2.chain.sendRawTransaction(
+        fundTx.serialize().toString('hex'),
+      );
+      expect(fundTxId).to.not.be.undefined;
+
+      oracleAttestation = generateDdkCompatibleEnumOracleAttestation(
+        'trump',
+        oracle,
+        announcement.getEventId(),
+      );
+
+      oracleAttestation.validate();
+
+      const refundTx = await ddk2.dlc.refund(
+        dlcOffer,
+        dlcAccept,
+        dlcSign,
+        dlcTransactions,
+      );
+
+      const refundTxId = await bob.chain.sendRawTransaction(
+        refundTx.serialize().toString('hex'),
+      );
+      console.log('refundTxId', refundTxId);
+      expect(refundTxId).to.not.be.undefined;
+      const refundTransaction = await alice.getMethod('getTransactionByHash')(
+        refundTxId,
+      );
+      expect(refundTransaction._raw.vin.length).to.equal(1);
+    });
+
     describe('ddk provider contract id computation', () => {
       it('should compute contract ID matching Rust implementation', async () => {
         // Test data from Rust test case


### PR DESCRIPTION
## Summary
Fixes refund signature creation and execution by replacing DDK-based methods with PSBT-based approaches that use proper P2WSH multisig scripts, resolving signature verification errors.

## Problem
The DDK provider was using DDK's `getRawFundingTransactionInputSignature` method for refund signature creation, which was producing signatures that failed Bitcoin's script verification with the error:

```
non-mandatory-script-verify-flag (Signature must be zero for failed CHECK(MULTI)SIG operation)
```


## Solution
- **Replaced refund signature creation** in `CreateCetAdaptorAndRefundSigs` with new `createRefundSignaturePSBT` method
- **Updated refund execution** in `refund` method to use the same P2WSH multisig approach as `createDlcClose`
- **Consistent script handling** across all DLC operations using proper P2MS → P2WSH payment variants

## Technical Details
Both methods now follow the exact same pattern as `createDlcClose`:
1. Create P2MS multisig script with properly sorted funding pubkeys
2. Wrap in P2WSH payment variant
3. Use proper `witnessUtxo` and `witnessScript` setup
4. Handle locktime correctly for refund transactions
5. Convert signatures between DER and compact formats as needed

## Testing
- Fixes the failing "should fund and execute enum DLC" test in the DDK provider
- Ensures refund signatures are compatible with Bitcoin's script verification
- Maintains compatibility with existing DLC message formats

## Breaking Changes
None - this is an internal implementation fix that doesn't affect the public API.

## Fixes
Resolves signature verification errors when executing DLC refund transactions using the DDK provider.