### PR TITLE
fix: ensure consistent sequence numbers in funding signature verification

### DIFF
--- a/.changeset/dirty-zoos-flash.md
+++ b/.changeset/dirty-zoos-flash.md
@@ -1,0 +1,24 @@
+---
+'@atomicfinance/bitcoin-ddk-provider': patch
+'@atomicfinance/bitcoin-cfd-address-derivation-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-ddk-address-derivation-provider': patch
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Ensure consistent sequence numbers in funding sig verification

--- a/tests/integration/common.ts
+++ b/tests/integration/common.ts
@@ -266,7 +266,18 @@ async function getInput(
     }
   }
 
-  await client.getMethod('jsonrpc')('importaddress', unusedAddress, '', false);
+  // Try to import address, but don't fail if Bitcoin Core doesn't support it
+  try {
+    await client.getMethod('jsonrpc')(
+      'importaddress',
+      unusedAddress,
+      '',
+      false,
+    );
+  } catch (error) {
+    // Ignore importaddress errors - modern Bitcoin Core uses descriptor wallets
+    console.warn(`Failed to import address ${unusedAddress}: ${error.message}`);
+  }
 
   const txRaw = await fundAddress(unusedAddress);
   const tx = await decodeRawTransaction(txRaw._raw.hex, network);


### PR DESCRIPTION
## What

Ensure consistent sequence numbers in funding signature verification

Also add `getFundingTransactionSighash` and `getFundingTransactionSighashDetails` to be able to verify sighash