### PR TITLE
refactor: extract funding input sorting utility & cleanup

### DIFF
--- a/.changeset/salty-cities-brush.md
+++ b/.changeset/salty-cities-brush.md
@@ -1,0 +1,24 @@
+---
+'@atomicfinance/bitcoin-ddk-provider': patch
+'@atomicfinance/bitcoin-cfd-address-derivation-provider': patch
+'@atomicfinance/bitcoin-cfd-provider': patch
+'@atomicfinance/bitcoin-ddk-address-derivation-provider': patch
+'@atomicfinance/bitcoin-dlc-provider': patch
+'@atomicfinance/bitcoin-esplora-api-provider': patch
+'@atomicfinance/bitcoin-esplora-batch-api-provider': patch
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+'@atomicfinance/bitcoin-node-wallet-provider': patch
+'@atomicfinance/bitcoin-rpc-provider': patch
+'@atomicfinance/bitcoin-utils': patch
+'@atomicfinance/bitcoin-wallet-provider': patch
+'@atomicfinance/client': patch
+'@atomicfinance/crypto': patch
+'@atomicfinance/errors': patch
+'@atomicfinance/jsonrpc-provider': patch
+'@atomicfinance/node-provider': patch
+'@atomicfinance/provider': patch
+'@atomicfinance/types': patch
+'@atomicfinance/utils': patch
+---
+
+Refactor funding input sorting

--- a/packages/bitcoin-ddk-provider/lib/utils/Utils.ts
+++ b/packages/bitcoin-ddk-provider/lib/utils/Utils.ts
@@ -5,6 +5,7 @@ import {
   DlcOffer,
   DlcSign,
   DlcTransactions,
+  FundingInput,
   MessageType,
 } from '@node-dlc/messaging';
 import { BitcoinNetwork } from 'bitcoin-network';
@@ -438,4 +439,12 @@ export function computeContractId(
   result[31] ^= fundOutputIndex & 0xff; // Low byte
 
   return result;
+}
+
+export function sortFundingInputsBySerialId(
+  inputs: FundingInput[],
+): FundingInput[] {
+  return inputs.sort(
+    (a, b) => Number(a.inputSerialId) - Number(b.inputSerialId),
+  );
 }

--- a/tests/integration/dlc/dlc.test.ts
+++ b/tests/integration/dlc/dlc.test.ts
@@ -706,8 +706,6 @@ describe('dlc provider', () => {
         fundTxId2,
       );
 
-      console.log('fundTx2Details', fundTx2Details);
-
       // Verify the second DLC has proper funding
       expect(fundTx2Details._raw.vout.length).to.be.greaterThan(0);
 


### PR DESCRIPTION
### Changes Made

#### New Utility Function
- **`sortFundingInputsBySerialId()`** - centralized function for sorting funding inputs by serial ID
- handles the common pattern of `Number(a.inputSerialId) - Number(b.inputSerialId)`
- ensures consistent sorting behavior across all DLC operations

#### Code Simplification
- replace 6+ instances of manual funding input sorting with utility function calls
- simplify `FindOutcomeIndexFromHyperbolaPayoutCurvePiece` by removing unnecessary parameter wrapping
- remove redundant type casting in funding input processing
- clean up array creation and sorting boilerplate

#### Code Cleanup
- remove debug `console.log` statements from tests
- improve readability by reducing nested operations

### Benefits
- **reduced duplication**: eliminates repeated sorting logic
- **better maintainability**: changes to sorting behavior only need to be made in one place
- **improved readability**: cleaner, more concise code

### Impact
- no functional changes - all existing behavior preserved
- improved code organization and maintainability
- follows established pattern of extracting common utilities

This refactoring builds on the previous utility extraction work and continues to improve the codebase organization while maintaining full backward compatibility.