### PR TITLE
feat: add BitcoinSatsConnectProvider and DLC debugging utilities

### DIFF
--- a/.changeset/empty-adults-live.md
+++ b/.changeset/empty-adults-live.md
@@ -1,0 +1,25 @@
+---
+'@atomicfinance/bitcoin-sats-connect-provider': minor
+'@atomicfinance/bitcoin-js-wallet-provider': minor
+'@atomicfinance/bitcoin-ddk-provider': minor
+'@atomicfinance/client': minor
+'@atomicfinance/types': minor
+'@atomicfinance/bitcoin-cfd-address-derivation-provider': minor
+'@atomicfinance/bitcoin-cfd-provider': minor
+'@atomicfinance/bitcoin-ddk-address-derivation-provider': minor
+'@atomicfinance/bitcoin-dlc-provider': minor
+'@atomicfinance/bitcoin-esplora-api-provider': minor
+'@atomicfinance/bitcoin-esplora-batch-api-provider': minor
+'@atomicfinance/bitcoin-node-wallet-provider': minor
+'@atomicfinance/bitcoin-rpc-provider': minor
+'@atomicfinance/bitcoin-utils': minor
+'@atomicfinance/bitcoin-wallet-provider': minor
+'@atomicfinance/crypto': minor
+'@atomicfinance/errors': minor
+'@atomicfinance/jsonrpc-provider': minor
+'@atomicfinance/node-provider': minor
+'@atomicfinance/provider': minor
+'@atomicfinance/utils': minor
+---
+
+Introduce new BitcoinSatsConnectProvider

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "packageManager": "pnpm@8.15.0",
   "devDependencies": {
-    "@bennyblader/ddk-ts": "^0.3.31",
+    "@bennyblader/ddk-ts": "^0.3.33",
     "@changesets/cli": "^2.22.0",
     "@node-dlc/bitcoin": "1.1.7",
     "@node-dlc/bufio": "1.1.7",
@@ -73,6 +73,7 @@
     "test:unit": "turbo run test:unit",
     "test:integration": "cross-env NODE_ENV=test NODE_OPTIONS=--import=tsx nyc --reporter=text --reporter=lcov mocha --require dotenv/config --require source-map-support/register --extension ts,tsx --timeout 60000 --max-old-space-size=4096 \"tests/integration/**/*.ts\"",
     "test:integration:sequential": "cross-env NODE_ENV=test NODE_OPTIONS=--import=tsx nyc --reporter=text --reporter=lcov mocha --require dotenv/config --require source-map-support/register --extension ts,tsx --timeout 60000 --max-old-space-size=4096 \"tests/integration/**/*.ts\"",
+    "test:message:verification": "cross-env NODE_ENV=test NODE_OPTIONS=--import=tsx nyc --reporter=text --reporter=lcov mocha --require dotenv/config --require source-map-support/register --extension ts,tsx --timeout 60000 --max-old-space-size=4096 --grep \"DLC Message Verification|DLC Adaptor Signature Verification\" \"tests/integration/dlc/dlc-message-verification.test.ts\"",
     "prepublishOnly": "pnpm build",
     "changeset": "changeset",
     "version": "pnpm changeset version",

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinSingleKeyWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinSingleKeyWalletProvider.ts
@@ -1,0 +1,595 @@
+import {
+  decodeRawTransaction,
+  normalizeTransactionObject,
+  selectCoins,
+} from '@atomicfinance/bitcoin-utils';
+import BitcoinWalletProvider from '@atomicfinance/bitcoin-wallet-provider';
+import Provider from '@atomicfinance/provider';
+import {
+  Address,
+  bitcoin as bT,
+  Input,
+  Output,
+  Transaction,
+} from '@atomicfinance/types';
+import * as ecc from '@bitcoin-js/tiny-secp256k1-asmjs';
+import { BIP32Interface, fromPrivateKey } from 'bip32';
+import { BitcoinNetwork } from 'bitcoin-network';
+import {
+  Psbt,
+  script,
+  Transaction as BitcoinJsTransaction,
+} from 'bitcoinjs-lib';
+import { ECPairFactory, ECPairInterface } from 'ecpair';
+
+const ECPair = ECPairFactory(ecc);
+import { signAsync as signBitcoinMessage } from 'bitcoinjs-message';
+
+const FEE_PER_BYTE_FALLBACK = 5;
+const DERIVATION_PATH = 'm/0';
+
+type WalletProviderConstructor<T = Provider> = new (...args: unknown[]) => T;
+
+interface BitcoinSingleKeyWalletProviderOptions {
+  network: BitcoinNetwork;
+  privateKey: string; // Hex format (64 chars) or WIF format
+  addressType?: bT.AddressType;
+}
+
+// TypeScript has difficulty inferring the complex return type of the mixin pattern
+// Using 'any' here is safe as we know the mixin returns the correct enhanced class
+const BaseProvider: any = BitcoinWalletProvider(
+  Provider as WalletProviderConstructor,
+);
+
+/**
+ * A wallet provider for a single private key (no HD derivation).
+ * Useful for simple use cases where you have one private key and don't need
+ * hierarchical deterministic wallet features.
+ */
+export default class BitcoinSingleKeyWalletProvider extends BaseProvider {
+  _keyPair: ECPairInterface;
+  _address: Address;
+
+  constructor(options: BitcoinSingleKeyWalletProviderOptions) {
+    const {
+      network,
+      privateKey,
+      addressType = bT.AddressType.BECH32,
+    } = options;
+
+    // Call parent with minimal required options
+    super({
+      network,
+      baseDerivationPath: DERIVATION_PATH,
+      addressType,
+      addressIndex: 0,
+      changeAddressIndex: 0,
+    });
+
+    // Parse private key (hex or WIF format)
+    this._keyPair = this._parsePrivateKey(privateKey, network);
+
+    // Pre-compute the single address
+    const publicKey = this._keyPair.publicKey;
+    const addressString = this.getAddressFromPublicKey(publicKey);
+    this._address = new Address({
+      address: addressString,
+      publicKey: publicKey.toString('hex'),
+      derivationPath: DERIVATION_PATH,
+    });
+
+    // Cache in derivation cache for compatibility
+    this._derivationCache[DERIVATION_PATH] = this._address;
+  }
+
+  private _parsePrivateKey(
+    privateKey: string,
+    network: BitcoinNetwork,
+  ): ECPairInterface {
+    // Check if WIF format (starts with 5, K, L, c, or 9 and is ~52 chars)
+    if (
+      privateKey.length >= 51 &&
+      privateKey.length <= 52 &&
+      /^[5KLc9]/.test(privateKey)
+    ) {
+      return ECPair.fromWIF(privateKey, network);
+    }
+
+    // Otherwise treat as hex (with or without 0x prefix)
+    let hexKey = privateKey;
+    if (hexKey.startsWith('0x')) {
+      hexKey = hexKey.slice(2);
+    }
+
+    if (hexKey.length !== 64) {
+      throw new Error(
+        'Private key must be 64 hex characters or valid WIF format',
+      );
+    }
+
+    return ECPair.fromPrivateKey(Buffer.from(hexKey, 'hex'), { network });
+  }
+
+  /**
+   * Returns the ECPair for signing. Derivation path is ignored since we have a single key.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async keyPair(_derivationPath?: string): Promise<ECPairInterface> {
+    return this._keyPair;
+  }
+
+  /**
+   * Required by parent class but not really used for single-key wallet.
+   * Returns a BIP32 node created from the private key.
+   */
+  async baseDerivationNode(): Promise<BIP32Interface> {
+    return fromPrivateKey(
+      this._keyPair.privateKey,
+      Buffer.alloc(32), // chainCode not used
+      this._network,
+    );
+  }
+
+  /**
+   * Returns the single address. Parameters are ignored.
+   */
+  async getAddresses(
+    _startingIndex = 0, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _numAddresses = 1, // eslint-disable-line @typescript-eslint/no-unused-vars
+    _change = false, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<Address[]> {
+    return [this._address];
+  }
+
+  /**
+   * Returns the single address.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getUnusedAddress(_change = false): Promise<Address> {
+    return this._address;
+  }
+
+  /**
+   * Checks if the requested address matches our single address.
+   */
+  async findAddress(
+    addresses: string[],
+    _change: boolean | null = null, // eslint-disable-line @typescript-eslint/no-unused-vars
+  ): Promise<Address | undefined> {
+    if (addresses.includes(this._address.address)) {
+      return this._address;
+    }
+    return undefined;
+  }
+
+  /**
+   * Returns the single address if it's used, empty array otherwise.
+   */
+  async getUsedAddresses(): Promise<Address[]> {
+    const transactionCounts = await this.getMethod(
+      'getAddressTransactionCounts',
+    )([this._address]);
+    if (transactionCounts[this._address.address] > 0) {
+      return [this._address];
+    }
+    return [];
+  }
+
+  /**
+   * Returns the wallet address if it matches.
+   */
+  async getWalletAddress(address: string): Promise<Address> {
+    if (address === this._address.address) {
+      return this._address;
+    }
+    throw new Error('Wallet does not contain address');
+  }
+
+  async exportPrivateKey(): Promise<string> {
+    return this._keyPair.toWIF();
+  }
+
+  async signMessage(message: string, from: string): Promise<string> {
+    if (from !== this._address.address) {
+      throw new Error('Address does not match wallet address');
+    }
+    const signature = await signBitcoinMessage(
+      message,
+      this._keyPair.privateKey,
+      this._keyPair.compressed,
+    );
+    return signature.toString('hex');
+  }
+
+  async _buildTransaction(
+    targets: bT.OutputTarget[],
+    feePerByte?: number,
+    fixedInputs?: bT.Input[],
+  ): Promise<{ hex: string; fee: number }> {
+    const network = this._network;
+
+    const { inputs, change, fee } = await this.getInputsForAmount(
+      targets,
+      feePerByte,
+      fixedInputs,
+    );
+
+    if (change) {
+      targets.push({
+        address: this._address.address,
+        value: change.value,
+      });
+    }
+
+    const psbt = new Psbt({ network });
+
+    const needsWitness = [
+      bT.AddressType.BECH32,
+      bT.AddressType.P2SH_SEGWIT,
+    ].includes(this._addressType);
+
+    for (let i = 0; i < inputs.length; i++) {
+      const paymentVariant = this.getPaymentVariantFromPublicKey(
+        this._keyPair.publicKey,
+      );
+
+      const psbtInput: any = {
+        hash: inputs[i].txid,
+        index: inputs[i].vout,
+        sequence: 0,
+      };
+
+      if (needsWitness) {
+        psbtInput.witnessUtxo = {
+          script: paymentVariant.output,
+          value: inputs[i].value,
+        };
+      } else {
+        const inputTxRaw = await this.getMethod('getRawTransactionByHash')(
+          inputs[i].txid,
+        );
+        psbtInput.nonWitnessUtxo = Buffer.from(inputTxRaw, 'hex');
+      }
+
+      if (this._addressType === bT.AddressType.P2SH_SEGWIT) {
+        psbtInput.redeemScript = paymentVariant.redeem.output;
+      }
+
+      psbt.addInput(psbtInput);
+    }
+
+    for (const output of targets) {
+      if (output.script) {
+        psbt.addOutput({
+          value: output.value,
+          script: output.script,
+        });
+      } else {
+        psbt.addOutput({
+          value: output.value,
+          address: output.address,
+        });
+      }
+    }
+
+    for (let i = 0; i < inputs.length; i++) {
+      psbt.signInput(i, this._keyPair);
+      psbt.validateSignaturesOfInput(
+        i,
+        (pubkey: Buffer, msghash: Buffer, signature: Buffer) =>
+          ecc.verify(msghash, pubkey, signature),
+      );
+    }
+
+    psbt.finalizeAllInputs();
+
+    return { hex: psbt.extractTransaction().toHex(), fee };
+  }
+
+  async _buildSweepTransaction(
+    externalChangeAddress: string,
+    feePerByte: number,
+  ): Promise<{ hex: string; fee: number }> {
+    let _feePerByte = feePerByte || null;
+    if (!_feePerByte) _feePerByte = await this.getMethod('getFeePerByte')();
+
+    const { inputs, outputs, change } = await this.getInputsForAmount(
+      [],
+      _feePerByte,
+      [],
+      100,
+      true,
+    );
+
+    if (change) {
+      throw new Error(
+        'There should not be any change for sweeping transaction',
+      );
+    }
+
+    const _outputs = [
+      {
+        address: externalChangeAddress,
+        value: outputs[0].value,
+      },
+    ];
+
+    return this._buildTransaction(
+      _outputs,
+      feePerByte,
+      inputs as unknown as bT.Input[],
+    );
+  }
+
+  async signPSBT(data: string, inputs: bT.PsbtInputTarget[]): Promise<string> {
+    const psbt = Psbt.fromBase64(data, { network: this._network });
+    for (const input of inputs) {
+      // Ignore derivationPath, use our single key
+      psbt.signInput(input.index, this._keyPair);
+    }
+    return psbt.toBase64();
+  }
+
+  async signBatchP2SHTransaction(
+    inputs: [
+      {
+        inputTxHex: string;
+        index: number;
+        vout: any;
+        outputScript: Buffer;
+        txInputIndex?: number;
+      },
+    ],
+    _addresses: string,
+    tx: any,
+    _lockTime?: number,
+    segwit?: boolean,
+  ): Promise<Buffer[]> {
+    const sigs: Buffer[] = [];
+
+    for (let i = 0; i < inputs.length; i++) {
+      const index = inputs[i].txInputIndex
+        ? inputs[i].txInputIndex
+        : inputs[i].index;
+      let sigHash;
+      if (segwit) {
+        sigHash = tx.hashForWitnessV0(
+          index,
+          inputs[i].outputScript,
+          inputs[i].vout.vSat,
+          BitcoinJsTransaction.SIGHASH_ALL,
+        );
+      } else {
+        sigHash = tx.hashForSignature(
+          index,
+          inputs[i].outputScript,
+          BitcoinJsTransaction.SIGHASH_ALL,
+        );
+      }
+
+      const sig = script.signature.encode(
+        this._keyPair.sign(sigHash),
+        BitcoinJsTransaction.SIGHASH_ALL,
+      );
+      sigs.push(sig);
+    }
+
+    return sigs;
+  }
+
+  async sendSweepTransactionWithSetOutputs(
+    externalChangeAddress: string,
+    feePerByte: number,
+    _outputs: Output[],
+    fixedInputs: Input[],
+  ): Promise<Transaction<bT.Transaction>> {
+    const { hex, fee } = await this._buildSweepTransactionWithSetOutputs(
+      externalChangeAddress,
+      feePerByte,
+      _outputs,
+      fixedInputs,
+    );
+    await this.getMethod('sendRawTransaction')(hex);
+    return normalizeTransactionObject(
+      decodeRawTransaction(hex, this._network),
+      fee,
+    );
+  }
+
+  async buildSweepTransactionWithSetOutputs(
+    externalChangeAddress: string,
+    feePerByte: number,
+    _outputs: Output[],
+    fixedInputs: Input[],
+  ): Promise<{ hex: string; fee: number }> {
+    return this._buildSweepTransactionWithSetOutputs(
+      externalChangeAddress,
+      feePerByte,
+      _outputs,
+      fixedInputs,
+    );
+  }
+
+  async _buildSweepTransactionWithSetOutputs(
+    externalChangeAddress: string,
+    feePerByte: number,
+    _outputs: Output[] = [],
+    fixedInputs: Input[],
+  ): Promise<{ hex: string; fee: number }> {
+    const _feePerByte =
+      feePerByte ||
+      (await this.getMethod('getFeePerByte')()) ||
+      FEE_PER_BYTE_FALLBACK;
+    const inputs: Input[] = [];
+    const outputs: Output[] = [];
+
+    try {
+      const inputsForAmount = await this.getInputsForAmount(
+        _outputs,
+        _feePerByte,
+        fixedInputs as unknown as bT.Input[],
+        100,
+        true,
+      );
+      if (inputsForAmount.change) {
+        throw Error('There should not be any change for sweeping transaction');
+      }
+      inputs.push(...((inputsForAmount.inputs as Input[]) || []));
+      outputs.push(...(inputsForAmount.outputs || []));
+    } catch {
+      if (fixedInputs.length === 0) {
+        throw Error(
+          `Inputs for amount doesn't exist and no fixedInputs provided`,
+        );
+      }
+
+      const inputsForAmount = this._getInputForAmountWithoutUtxoCheck(
+        _outputs,
+        _feePerByte,
+        fixedInputs,
+      );
+      inputs.push(
+        ...(inputsForAmount.inputs.map((utxo) => Input.fromUTXO(utxo)) || []),
+      );
+      outputs.push(...(inputsForAmount.outputs || []));
+    }
+
+    _outputs.forEach((output) => {
+      const spliceIndex = outputs.findIndex(
+        (sweepOutput: Output) => output.value === sweepOutput.value,
+      );
+      outputs.splice(spliceIndex, 1);
+    });
+
+    _outputs.push({
+      to: externalChangeAddress,
+      value: outputs[0].value,
+    });
+
+    return this._buildTransactionWithoutUtxoCheck(
+      _outputs,
+      _feePerByte,
+      inputs,
+    );
+  }
+
+  _getInputForAmountWithoutUtxoCheck(
+    _outputs: Output[],
+    _feePerByte: number,
+    fixedInputs: Input[],
+  ): {
+    inputs: bT.UTXO[];
+    outputs: { value: number; id?: string }[];
+    fee: number;
+    change: { value: number; id?: string };
+  } {
+    const utxoBalance = fixedInputs.reduce((a, b) => a + (b['value'] || 0), 0);
+    const outputBalance = _outputs.reduce((a, b) => a + (b['value'] || 0), 0);
+    const amountToSend =
+      utxoBalance -
+      _feePerByte * ((_outputs.length + 1) * 39 + fixedInputs.length * 153);
+
+    const targets = _outputs.map((target) => ({
+      id: 'main',
+      value: target.value,
+    }));
+    if (amountToSend - outputBalance > 0) {
+      targets.push({ id: 'main', value: amountToSend - outputBalance });
+    }
+
+    return selectCoins(
+      fixedInputs,
+      targets,
+      Math.ceil(_feePerByte),
+      fixedInputs,
+    );
+  }
+
+  async _buildTransactionWithoutUtxoCheck(
+    outputs: Output[],
+    feePerByte: number,
+    fixedInputs: Input[],
+  ): Promise<{ hex: string; fee: number }> {
+    const network = this._network;
+
+    const { fee } = this._getInputForAmountWithoutUtxoCheck(
+      outputs,
+      feePerByte,
+      fixedInputs,
+    );
+    const inputs = fixedInputs;
+
+    const psbt = new Psbt({ network });
+
+    const needsWitness = [
+      bT.AddressType.BECH32,
+      bT.AddressType.P2SH_SEGWIT,
+    ].includes(this._addressType);
+
+    for (let i = 0; i < inputs.length; i++) {
+      const paymentVariant = this.getPaymentVariantFromPublicKey(
+        this._keyPair.publicKey,
+      );
+
+      const psbtInput: any = {
+        hash: inputs[i].txid,
+        index: inputs[i].vout,
+        sequence: 0,
+      };
+
+      if (needsWitness) {
+        psbtInput.witnessUtxo = {
+          script: paymentVariant.output,
+          value: inputs[i].value,
+        };
+      } else {
+        const inputTxRaw = await this.getMethod('getRawTransactionByHash')(
+          inputs[i].txid,
+        );
+        psbtInput.nonWitnessUtxo = Buffer.from(inputTxRaw, 'hex');
+      }
+
+      if (this._addressType === bT.AddressType.P2SH_SEGWIT) {
+        psbtInput.redeemScript = paymentVariant.redeem.output;
+      }
+
+      psbt.addInput(psbtInput);
+    }
+
+    for (const output of outputs) {
+      psbt.addOutput({
+        value: output.value,
+        address: output.to,
+      });
+    }
+
+    for (let i = 0; i < inputs.length; i++) {
+      psbt.signInput(i, this._keyPair);
+      psbt.validateSignaturesOfInput(
+        i,
+        (pubkey: Buffer, msghash: Buffer, signature: Buffer) =>
+          ecc.verify(msghash, pubkey, signature),
+      );
+    }
+
+    psbt.finalizeAllInputs();
+
+    return { hex: psbt.extractTransaction().toHex(), fee };
+  }
+
+  getScriptType(): string {
+    if (this._addressType === bT.AddressType.LEGACY) return 'p2pkh';
+    else if (this._addressType === bT.AddressType.P2SH_SEGWIT)
+      return 'p2sh-p2wpkh';
+    else if (this._addressType === bT.AddressType.BECH32) return 'p2wpkh';
+  }
+
+  async getConnectedNetwork(): Promise<BitcoinNetwork> {
+    return this._network;
+  }
+
+  async isWalletAvailable(): Promise<boolean> {
+    return true;
+  }
+}

--- a/packages/bitcoin-js-wallet-provider/lib/index.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/index.ts
@@ -1,3 +1,4 @@
 import BitcoinJsWalletProvider from './BitcoinJsWalletProvider';
+import BitcoinSingleKeyWalletProvider from './BitcoinSingleKeyWalletProvider';
 
-export { BitcoinJsWalletProvider };
+export { BitcoinJsWalletProvider, BitcoinSingleKeyWalletProvider };

--- a/packages/bitcoin-sats-connect-provider/README.md
+++ b/packages/bitcoin-sats-connect-provider/README.md
@@ -1,0 +1,168 @@
+# @atomicfinance/bitcoin-sats-connect-provider
+
+Bitcoin provider for DLC operations with SatsConnect-compatible wallets.
+
+## Overview
+
+This package provides a `BitcoinSatsConnectProvider` that integrates with SatsConnect-compatible wallets (including Fordefi) for DLC operations. It's designed for the **offerer side** of DLC contracts.
+
+## Installation
+
+```bash
+npm install @atomicfinance/bitcoin-sats-connect-provider
+```
+
+## Features
+
+### Supported Operations (as DLC Offerer)
+
+- `createDlcOffer()` - Create DLC offers with fixed inputs
+- `signDlcAccept()` - Sign the accept message (funding, refund, CET adaptor signatures)
+- `signCetForExecution()` - Sign CET for execution
+- `getAddresses()` / `getPaymentAddress()` / `getOrdinalsAddress()`
+- `isConnected()`
+
+### Contract Types
+
+- **Enum contracts only** - Only `EnumeratedDescriptor` contracts are supported (not numeric)
+
+## Usage
+
+### With FordefiWalletEmulator (for testing)
+
+```typescript
+import {
+  BitcoinSatsConnectProvider,
+  FordefiWalletEmulator,
+} from '@atomicfinance/bitcoin-sats-connect-provider';
+import * as ddkJs from '@bennyblader/ddk-ts';
+import { BitcoinNetworks } from 'bitcoin-network';
+
+const network = BitcoinNetworks.bitcoin_regtest;
+
+// Create wallet emulator for testing
+const wallet = new FordefiWalletEmulator({
+  network,
+  privateKey: 'your-private-key-hex', // 64 hex chars
+  ddk: ddkJs,
+});
+
+// Create provider
+const satsConnectProvider = new BitcoinSatsConnectProvider({
+  network,
+  wallet,
+  ddk: ddkJs,
+});
+
+// Add to client
+client.addProvider(satsConnectProvider);
+```
+
+### With Real SatsConnect Wallet
+
+```typescript
+import { BitcoinSatsConnectProvider } from '@atomicfinance/bitcoin-sats-connect-provider';
+import * as ddkJs from '@bennyblader/ddk-ts';
+
+// Your SatsConnect-compatible wallet must implement WalletInterface
+const wallet: WalletInterface = yourSatsConnectWallet;
+
+const satsConnectProvider = new BitcoinSatsConnectProvider({
+  network,
+  wallet,
+  ddk: ddkJs,
+});
+```
+
+### WalletInterface
+
+Any wallet passed to the provider must implement:
+
+```typescript
+interface WalletInterface {
+  request<T>(method: string, params?: unknown): Promise<SatsConnectResponse<T>>;
+}
+
+interface SatsConnectResponse<T> {
+  status: 'success' | 'error';
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+```
+
+Required methods:
+- `getAddresses` - Returns wallet addresses
+- `dlc_signOffer` - Signs funding, refund, and creates CET adaptor signatures
+- `signPsbt` - Standard PSBT signing (for CET execution)
+- `wallet_getAccount` - Connection check
+
+## DLC Flow Example
+
+```typescript
+// 1. Create DLC offer (offerer)
+const dlcOffer = await client.dlc.createDlcOffer(
+  contractInfo,
+  offerCollateralSatoshis,
+  feeRatePerVb,
+  cetLocktime,
+  refundLocktime,
+  fixedInputs,
+);
+
+// 2. Accept DLC offer (accepter - uses BitcoinDdkProvider)
+const { dlcAccept, dlcTransactions } = await accepterClient.dlc.acceptDlcOffer(dlcOffer);
+
+// 3. Sign DLC accept (offerer - uses BitcoinSatsConnectProvider)
+const { dlcSign } = await client.dlc.signDlcAccept(dlcOffer, dlcAccept, dlcTransactions);
+
+// 4. Finalize and broadcast funding transaction
+const fundingTx = await accepterClient.dlc.finalizeDlcSign(
+  dlcOffer,
+  dlcAccept,
+  dlcSign,
+  dlcTransactions,
+);
+
+// 5. Execute CET when oracle attests
+const cet = await client.dlc.execute(
+  dlcOffer,
+  dlcAccept,
+  dlcSign,
+  dlcTransactions,
+  oracleAttestation,
+  outcomeIndex,
+);
+```
+
+## Requirements
+
+- **DDK** - You must provide a DDK instance (`@bennyblader/ddk-ts`) for adaptor signature creation
+- **Wallet** - A SatsConnect-compatible wallet or the included `FordefiWalletEmulator`
+
+## Components
+
+### BitcoinSatsConnectProvider
+
+Main provider class that handles DLC operations by delegating signing to a SatsConnect-compatible wallet.
+
+### FordefiWalletEmulator
+
+A local wallet emulator for testing that implements the `WalletInterface`. It uses DDK directly to create adaptor signatures, simulating what Fordefi wallet does.
+
+```typescript
+const emulator = new FordefiWalletEmulator({
+  network,
+  privateKey: 'hex-private-key', // or WIF format
+  // OR use mnemonic:
+  mnemonic: 'your twelve word mnemonic phrase ...',
+  baseDerivationPath: "m/84'/0'/0'",
+  ddk: ddkJs,
+});
+```
+
+## License
+
+MIT

--- a/packages/bitcoin-sats-connect-provider/lib/BitcoinSatsConnectProvider.ts
+++ b/packages/bitcoin-sats-connect-provider/lib/BitcoinSatsConnectProvider.ts
@@ -1,0 +1,1090 @@
+import Provider from '@atomicfinance/provider';
+import {
+  DdkInterface,
+  DdkOracleInfo,
+  DdkTransaction,
+  Messages,
+  WalletProvider,
+} from '@atomicfinance/types';
+import { Sequence, Tx } from '@node-dlc/bitcoin';
+import { StreamReader } from '@node-dlc/bufio';
+import {
+  CetAdaptorSignatures,
+  ContractDescriptorType,
+  ContractInfo,
+  ContractInfoType,
+  DlcAccept,
+  DlcOffer,
+  DlcSign,
+  DlcTransactions,
+  EnumeratedDescriptor,
+  EnumEventDescriptor,
+  FundingInput,
+  FundingSignatures,
+  MessageType,
+  OracleInfo,
+  ScriptWitnessV0,
+  SingleContractInfo,
+  SingleOracleInfo,
+} from '@node-dlc/messaging';
+import { chainHashFromNetwork } from 'bitcoin-network';
+import { BitcoinNetwork, BitcoinNetworks } from 'bitcoin-network';
+import {
+  address,
+  crypto as bitcoinCrypto,
+  payments,
+  Psbt,
+  Transaction as btTransaction,
+} from 'bitcoinjs-lib';
+
+import {
+  AddressPurpose,
+  BitcoinSatsConnectProviderOptions,
+  SatsConnectAddress,
+  SatsConnectWalletAddress,
+  SignDlcResult,
+  WalletInterface,
+} from './types';
+
+/**
+ * Bitcoin provider that integrates with SatsConnect-compatible wallets
+ * (including Fordefi and our local FordefiWalletEmulator).
+ *
+ * This provider handles DLC operations including:
+ * - Creating DLC offers
+ * - Signing DLC accepts (funding, refund, and CET adaptor signatures)
+ * - CET execution signing
+ */
+export class BitcoinSatsConnectProvider
+  extends Provider
+  implements Partial<WalletProvider>
+{
+  private wallet: WalletInterface;
+  private network: BitcoinNetwork;
+  private _ddk: DdkInterface;
+
+  constructor(
+    options: BitcoinSatsConnectProviderOptions & { ddk: DdkInterface },
+  ) {
+    super();
+
+    if (!options.wallet) {
+      throw new Error(
+        'wallet is required - pass a WalletInterface implementation',
+      );
+    }
+
+    if (!options.ddk) {
+      throw new Error('ddk is required - pass a DdkInterface implementation');
+    }
+
+    this.wallet = options.wallet;
+    this.network = options.network ?? BitcoinNetworks.bitcoin_testnet;
+    this._ddk = options.ddk;
+  }
+
+  /**
+   * Get addresses from the wallet.
+   * @return {Promise<Address[]>} Resolves with a list of addresses.
+   */
+  async getAddresses(): Promise<SatsConnectAddress[]> {
+    try {
+      const response = await this.wallet.request<{
+        addresses: SatsConnectWalletAddress[];
+      }>('getAddresses', {
+        purposes: [AddressPurpose.Payment, AddressPurpose.Ordinals],
+      });
+
+      if (response.status === 'error') {
+        throw new Error(
+          `Wallet error: ${response.error?.message || 'Unknown error'}`,
+        );
+      }
+
+      if (!response.result?.addresses) {
+        throw new Error('No addresses returned from wallet');
+      }
+
+      // Convert wallet addresses to our Address format
+      return response.result.addresses
+        .filter(
+          (addr: SatsConnectWalletAddress) =>
+            addr.purpose === AddressPurpose.Payment ||
+            addr.purpose === AddressPurpose.Ordinals,
+        )
+        .map(
+          (addr: SatsConnectWalletAddress): SatsConnectAddress => ({
+            address: addr.address,
+            publicKey: addr.publicKey,
+            derivationPath: addr.derivationPath,
+            purpose: addr.purpose,
+          }),
+        );
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to get addresses from wallet: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Get a specific address by purpose
+   * @param purpose - The address purpose to filter by
+   * @return {Promise<Address | undefined>} Resolves with the address if found
+   */
+  async getAddressByPurpose(
+    purpose: AddressPurpose,
+  ): Promise<SatsConnectAddress | undefined> {
+    const addresses = await this.getAddresses();
+    return addresses.find((addr) => addr.purpose === purpose);
+  }
+
+  /**
+   * Get payment address (first payment address)
+   * @return {Promise<SatsConnectAddress>} Resolves with payment address
+   */
+  async getPaymentAddress(): Promise<SatsConnectAddress> {
+    const addr = await this.getAddressByPurpose(AddressPurpose.Payment);
+    if (!addr) {
+      throw new Error('No payment address available from wallet');
+    }
+    return addr;
+  }
+
+  /**
+   * Get ordinals address (first ordinals address)
+   * @return {Promise<SatsConnectAddress>} Resolves with ordinals address
+   */
+  async getOrdinalsAddress(): Promise<SatsConnectAddress> {
+    const addr = await this.getAddressByPurpose(AddressPurpose.Ordinals);
+    if (!addr) {
+      throw new Error('No ordinals address available from wallet');
+    }
+    return addr;
+  }
+
+  /**
+   * Check if the wallet is connected
+   * @return {Promise<boolean>} True if the wallet is connected
+   */
+  async isConnected(): Promise<boolean> {
+    try {
+      const response = await this.wallet.request(
+        'wallet_getAccount',
+        undefined,
+      );
+      return response.status === 'success';
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Create a DLC Offer
+   * @param contractInfo - Contract information from @node-dlc/messaging
+   * @param offerCollateralSatoshis - Amount the offerer is putting into the contract
+   * @param feeRatePerVb - Fee rate in satoshis per virtual byte
+   * @param cetLocktime - The nLockTime to be put on CETs
+   * @param refundLocktime - The nLockTime to be put on the refund transaction
+   * @param fixedInputs - Optional fixed inputs to use for funding
+   * @return {Promise<DlcOffer>} Resolves with a DLC offer object
+   */
+  async createDlcOffer(
+    contractInfo: ContractInfo,
+    offerCollateralSatoshis: bigint,
+    feeRatePerVb: bigint,
+    cetLocktime: number,
+    refundLocktime: number,
+    fixedInputs?: {
+      txid: string;
+      vout: number;
+      value: number;
+      txHex?: string;
+    }[],
+  ): Promise<DlcOffer> {
+    try {
+      // Validate contract info
+      contractInfo.validate();
+
+      if (offerCollateralSatoshis <= 0n) {
+        throw new Error('Offer collateral must be greater than 0');
+      }
+
+      if (offerCollateralSatoshis > contractInfo.totalCollateral) {
+        throw new Error(
+          'Offer collateral cannot exceed total contract collateral',
+        );
+      }
+
+      // Get payment address from wallet
+      const paymentAddress = await this.getPaymentAddress();
+
+      // Create the DLC offer
+      const dlcOffer = new DlcOffer();
+
+      // Generate a random temporary contract ID
+      dlcOffer.temporaryContractId = Buffer.from(
+        this.generateRandomHex(32),
+        'hex',
+      );
+      dlcOffer.contractInfo = contractInfo;
+      dlcOffer.fundingPubkey = Buffer.from(paymentAddress.publicKey, 'hex');
+      dlcOffer.payoutSpk = address.toOutputScript(
+        paymentAddress.address,
+        this.network,
+      );
+      dlcOffer.payoutSerialId = this.generateSerialId();
+      dlcOffer.offerCollateral = offerCollateralSatoshis;
+
+      // Get funding inputs - either use provided inputs or get from wallet
+      if (!fixedInputs || fixedInputs.length === 0) {
+        throw new Error('fixedInputs are required for createDlcOffer');
+      }
+
+      // Create funding inputs from provided UTXOs
+      dlcOffer.fundingInputs = await Promise.all(
+        fixedInputs.map(async (input, index) => {
+          // Get txHex if not provided
+          let txHex = input.txHex;
+          if (!txHex) {
+            txHex = await this.getMethod('getRawTransactionByHash')(input.txid);
+          }
+
+          const tx = Tx.decode(StreamReader.fromHex(txHex));
+          const fundingInput = new FundingInput();
+          fundingInput.inputSerialId = BigInt(index + 1);
+          fundingInput.prevTx = tx;
+          fundingInput.prevTxVout = input.vout;
+          fundingInput.sequence = Sequence.default();
+          fundingInput.maxWitnessLen = 108; // Standard witness length for P2WPKH
+          fundingInput.redeemScript = Buffer.from('', 'hex');
+          return fundingInput;
+        }),
+      );
+
+      dlcOffer.changeSpk = address.toOutputScript(
+        paymentAddress.address,
+        this.network,
+      );
+      dlcOffer.changeSerialId = this.generateSerialId();
+      dlcOffer.fundOutputSerialId = this.generateSerialId();
+      dlcOffer.feeRatePerVb = feeRatePerVb;
+      dlcOffer.cetLocktime = cetLocktime;
+      dlcOffer.refundLocktime = refundLocktime;
+      dlcOffer.contractFlags = Buffer.from('00', 'hex');
+      dlcOffer.chainHash = chainHashFromNetwork(this.network);
+
+      return dlcOffer;
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to create DLC offer: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Helper function to generate random hex string
+   */
+  private generateRandomHex(length: number): string {
+    const bytes = Buffer.alloc(length);
+    for (let i = 0; i < length; i++) {
+      bytes[i] = Math.floor(Math.random() * 256);
+    }
+    return bytes.toString('hex');
+  }
+
+  /**
+   * Helper function to generate a serial ID
+   */
+  private generateSerialId(): bigint {
+    return BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER));
+  }
+
+  /**
+   * Convert Tx to DDK Transaction format
+   */
+  private convertTxToDdkTransaction(tx: Tx): DdkTransaction {
+    return {
+      version: tx.version,
+      lockTime: tx.locktime.value,
+      inputs: tx.inputs.map((input) => ({
+        txid: input.outpoint.txid.toString(),
+        vout: input.outpoint.outputIndex,
+        scriptSig: Buffer.from(''),
+        sequence: input.sequence.value,
+        witness: input.witness.map((witness) => witness.serialize()),
+      })),
+      outputs: tx.outputs.map((output) => ({
+        value: BigInt(output.value.sats),
+        scriptPubkey: output.scriptPubKey.serialize(),
+      })),
+      rawBytes: tx.serialize(),
+    };
+  }
+
+  /**
+   * Get fund output value from DLC transactions
+   */
+  private getFundOutputValueSats(dlcTxs: DlcTransactions): bigint {
+    const fundOutput = dlcTxs.fundTx.outputs[dlcTxs.fundTxVout];
+    if (!fundOutput || !fundOutput.value) {
+      throw new Error(`Invalid fund output at vout ${dlcTxs.fundTxVout}`);
+    }
+    return fundOutput.value.sats;
+  }
+
+  /**
+   * Create 2-of-2 multisig script (not wrapped in P2WSH)
+   */
+  private createP2MSMultisig(pubkey1: Buffer, pubkey2: Buffer) {
+    const orderedPubkeys =
+      Buffer.compare(pubkey1, pubkey2) === -1
+        ? [pubkey1, pubkey2]
+        : [pubkey2, pubkey1];
+
+    return payments.p2ms({
+      m: 2,
+      pubkeys: orderedPubkeys,
+      network: this.network,
+    });
+  }
+
+  /**
+   * Compute tagged attestation message (SHA256 with DLC/attestation tag)
+   */
+  private computeTaggedAttestationMessage(outcome: string): string {
+    const tag = 'DLC/oracle/attestation/v0';
+    const tagHash = bitcoinCrypto.sha256(Buffer.from(tag, 'utf8'));
+    const message = Buffer.concat([
+      tagHash,
+      tagHash,
+      Buffer.from(outcome, 'utf8'),
+    ]);
+    return bitcoinCrypto.sha256(message).toString('hex');
+  }
+
+  /**
+   * Convert messages to DDK format (Buffer[][][])
+   */
+  private convertMessagesForDdk(messagesList: Messages[]): Buffer[][][] {
+    return messagesList.map((message) => [
+      message.messages.map((m) => {
+        return Buffer.from(this.computeTaggedAttestationMessage(m), 'hex');
+      }),
+    ]);
+  }
+
+  /**
+   * Get payouts and messages from enumerated contract descriptor
+   *
+   * IMPORTANT: Messages must come from the oracle event's outcomes (raw strings),
+   * NOT from the contract descriptor's outcomes (which may be hashed).
+   * The DDK provider uses GenerateEnumMessages which gets outcomes from
+   * oracleEvent.eventDescriptor.outcomes, and we must match that.
+   */
+  private getPayoutsFromEnumeratedDescriptor(
+    _dlcOffer: DlcOffer,
+    contractDescriptor: EnumeratedDescriptor,
+    oracleInfo: OracleInfo,
+    totalCollateral: bigint,
+  ): {
+    payouts: Array<{ offer: bigint; accept: bigint }>;
+    messagesList: Messages[];
+  } {
+    const payouts: Array<{ offer: bigint; accept: bigint }> = [];
+    const messagesList: Messages[] = [];
+
+    // Get raw outcome strings from the oracle event (like DDK provider does)
+    // The contract descriptor outcomes may be hashed, but the oracle event has raw strings
+    let oracleOutcomes: string[];
+    if (oracleInfo.type === MessageType.SingleOracleInfo) {
+      const singleOracleInfo = oracleInfo as SingleOracleInfo;
+      const eventDescriptor = singleOracleInfo.announcement.oracleEvent
+        .eventDescriptor as EnumEventDescriptor;
+      oracleOutcomes = eventDescriptor.outcomes;
+    } else {
+      throw new Error('Only SingleOracleInfo is supported');
+    }
+
+    // For each outcome in the contract, create payout and message
+    // Use oracle event outcomes for messages (raw strings that DDK will hash)
+    for (let i = 0; i < contractDescriptor.outcomes.length; i++) {
+      const outcomeInfo = contractDescriptor.outcomes[i];
+      const offerPayout = outcomeInfo.localPayout;
+      const acceptPayout = totalCollateral - offerPayout;
+
+      payouts.push({ offer: offerPayout, accept: acceptPayout });
+      // Use oracle event outcome (raw string) instead of contract descriptor outcome
+      messagesList.push({ messages: [oracleOutcomes[i]] });
+    }
+
+    return { payouts, messagesList };
+  }
+
+  /**
+   * Get payouts and messages from contract info
+   */
+  private getPayoutsFromContractInfo(dlcOffer: DlcOffer): {
+    payouts: Array<{ offer: bigint; accept: bigint }>;
+    messagesList: Messages[];
+  } {
+    const contractInfo = dlcOffer.contractInfo;
+    const totalCollateral = contractInfo.totalCollateral;
+
+    if (contractInfo.contractInfoType === ContractInfoType.Single) {
+      const singleContractInfo = contractInfo as SingleContractInfo;
+      const contractDescriptor = singleContractInfo.contractDescriptor;
+      const oracleInfo = singleContractInfo.oracleInfo;
+
+      if (
+        contractDescriptor.contractDescriptorType ===
+        ContractDescriptorType.Enumerated
+      ) {
+        return this.getPayoutsFromEnumeratedDescriptor(
+          dlcOffer,
+          contractDescriptor as EnumeratedDescriptor,
+          oracleInfo,
+          totalCollateral,
+        );
+      }
+    }
+
+    throw new Error(
+      'Only SingleContractInfo with EnumeratedDescriptor is supported',
+    );
+  }
+
+  /**
+   * Get oracle info in DDK format
+   */
+  private getOracleInfoForDdk(dlcOffer: DlcOffer): DdkOracleInfo[] {
+    const contractInfo = dlcOffer.contractInfo;
+
+    if (contractInfo.contractInfoType === ContractInfoType.Single) {
+      const singleContractInfo = contractInfo as SingleContractInfo;
+      const oracleInfo = singleContractInfo.oracleInfo;
+
+      if (oracleInfo.type === MessageType.SingleOracleInfo) {
+        const singleOracleInfo = oracleInfo as SingleOracleInfo;
+        const announcement = singleOracleInfo.announcement;
+
+        return [
+          {
+            publicKey: announcement.oraclePublicKey,
+            nonces: announcement.oracleEvent.oracleNonces,
+          },
+        ];
+      }
+    }
+
+    throw new Error('Only SingleOracleInfo is supported');
+  }
+
+  /**
+   * Sign DLC Accept using wallet (following DDK signDlcAccept pattern)
+   * @param dlcOffer - The DLC offer
+   * @param dlcAccept - The DLC accept message (optional, will use acceptDlcOffer response internally)
+   * @param dlcTransactions - The DLC transactions (optional, will use acceptDlcOffer response internally)
+   * @return {Promise<SignDlcAcceptResponse>} The DLC sign message with transactions
+   */
+  async signDlcAccept(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTransactions?: DlcTransactions,
+  ): Promise<{ dlcSign: DlcSign; dlcTransactions: DlcTransactions }> {
+    // If dlcTransactions is not provided, we still need it
+    if (!dlcTransactions) {
+      throw new Error('dlcTransactions is required for SatsConnectProvider');
+    }
+    try {
+      // Validate inputs
+      dlcOffer.validate();
+      dlcAccept.validate();
+
+      if (
+        Buffer.compare(dlcOffer.fundingPubkey, dlcAccept.fundingPubkey) === 0
+      ) {
+        throw new Error(
+          'DlcOffer and DlcAccept FundingPubKey cannot be the same',
+        );
+      }
+
+      // Create DLC sign message
+      const dlcSign = new DlcSign();
+
+      // Compute contract ID using funding transaction details
+      const fundTxId = dlcTransactions.fundTx.txId.serialize();
+      const fundOutputIndex = dlcTransactions.fundTxVout;
+      const temporaryContractId = dlcOffer.temporaryContractId;
+
+      // Contract ID computation (same as computeContractId in Utils.ts):
+      // 1. XOR fund_tx_id with temporary_id, with byte order reversal for fund_tx_id
+      // 2. XOR the fund output index into the last two bytes
+      const contractId = Buffer.alloc(32);
+      for (let i = 0; i < 32; i++) {
+        contractId[i] = fundTxId[31 - i] ^ temporaryContractId[i];
+      }
+      // XOR the fund output index into the last two bytes
+      contractId[30] ^= (fundOutputIndex >> 8) & 0xff; // High byte
+      contractId[31] ^= fundOutputIndex & 0xff; // Low byte
+      dlcSign.contractId = contractId;
+
+      // Create PSBTs for all transactions
+      const fundingPsbt = this.createFundingPsbt(
+        dlcOffer,
+        dlcAccept,
+        dlcTransactions,
+      );
+      const refundPsbt = this.createRefundPsbt(
+        dlcOffer,
+        dlcAccept,
+        dlcTransactions,
+      );
+
+      // Create CET PSBTs
+      const cetPsbts: Psbt[] = [];
+      const numCets = dlcTransactions.cets?.length || 0;
+      for (let i = 0; i < numCets; i++) {
+        const cetPsbt = this.createCetPsbt(
+          dlcOffer,
+          dlcAccept,
+          dlcTransactions,
+          i,
+        );
+        cetPsbts.push(cetPsbt);
+      }
+
+      // Get our addresses to determine which inputs we can sign
+      const addresses = await this.getAddresses();
+      const firstAddress = addresses[0]?.address;
+
+      if (!firstAddress) {
+        throw new Error('No wallet address available for signing');
+      }
+
+      // Find which inputs belong to our wallet for funding transaction
+      const allFundingInputs = [
+        ...dlcOffer.fundingInputs,
+        ...dlcAccept.fundingInputs,
+      ];
+      allFundingInputs.sort(
+        (a, b) => Number(a.inputSerialId) - Number(b.inputSerialId),
+      );
+
+      // Create a set of offerer input serial IDs for quick lookup
+      const offererInputSerialIds = new Set(
+        dlcOffer.fundingInputs.map((input) => input.inputSerialId.toString()),
+      );
+
+      // Find PSBT indexes that correspond to offerer inputs
+      const ourFundingInputIndexes: number[] = [];
+      allFundingInputs.forEach((input, psbtIndex) => {
+        if (offererInputSerialIds.has(input.inputSerialId.toString())) {
+          ourFundingInputIndexes.push(psbtIndex);
+        }
+      });
+
+      // Compute adaptor points using DDK
+      // This follows the Fordefi interface: wallet receives adaptorPoints, not messages
+      const { messagesList } = this.getPayoutsFromContractInfo(dlcOffer);
+      const oracleInfo = this.getOracleInfoForDdk(dlcOffer);
+      const messagesForDdk = this.convertMessagesForDdk(messagesList);
+
+      // Compute adaptor points from oracle info and messages
+      const adaptorPoints = this._ddk.createCetAdaptorPointsFromOracleInfo(
+        oracleInfo,
+        messagesForDdk,
+      );
+
+      // Convert adaptor points to base64 for the wallet interface
+      const adaptorPointsBase64 = adaptorPoints.map((point: Buffer) =>
+        point.toString('base64'),
+      );
+
+      // Get additional DDK params needed for emulator (not used by real Fordefi wallet)
+      const p2ms = this.createP2MSMultisig(
+        dlcOffer.fundingPubkey,
+        dlcAccept.fundingPubkey,
+      );
+      const fundingScriptPubkey = p2ms.output!;
+      const fundOutputValue = this.getFundOutputValueSats(dlcTransactions);
+      const cetsForDdk = dlcTransactions.cets.map((cet) =>
+        this.convertTxToDdkTransaction(cet),
+      );
+
+      // Build params matching Fordefi's dlc_signOffer interface
+      // Also includes DDK params for FordefiWalletEmulator (ignored by real Fordefi wallet)
+      const params = {
+        fundingTransaction: {
+          psbt: fundingPsbt.toBase64(),
+          signInputs:
+            ourFundingInputIndexes.length > 0
+              ? { [firstAddress]: ourFundingInputIndexes }
+              : undefined,
+        },
+        refundTransaction: {
+          psbt: refundPsbt.toBase64(),
+          signInputs: { [firstAddress]: [0] },
+        },
+        cetTransactions: cetPsbts.map((cetPsbt, index) => ({
+          psbt: cetPsbt.toBase64(),
+          adaptorPoint: adaptorPointsBase64[index],
+        })),
+        // DDK params for FordefiWalletEmulator (ignored by real Fordefi wallet)
+        cets: cetsForDdk,
+        oracleInfo: oracleInfo,
+        fundingScriptPubkey: fundingScriptPubkey,
+        fundOutputValue: fundOutputValue,
+        messages: messagesForDdk,
+      };
+
+      // Use dlc_signOffer method for unified signing
+      const signResponse = await this.wallet.request<SignDlcResult>(
+        'dlc_signOffer',
+        params,
+      );
+
+      if (signResponse.status === 'error') {
+        throw new Error(
+          `Failed to sign DLC transactions: ${signResponse.error?.message ?? 'Unknown error'}`,
+        );
+      }
+
+      if (!signResponse.result) {
+        throw new Error('No result in sign response');
+      }
+
+      const signResult = signResponse.result;
+
+      // Extract funding transaction signatures
+      const signedFundingPsbt = Psbt.fromBase64(signResult.fundingTransaction);
+      const fundingSignatures = new FundingSignatures();
+
+      const witnessElements: ScriptWitnessV0[][] = [];
+      for (const inputIndex of ourFundingInputIndexes) {
+        const input = signedFundingPsbt.data.inputs[inputIndex];
+        if (input?.partialSig && input.partialSig.length > 0) {
+          const partialSig = input.partialSig[0];
+          const signature = partialSig.signature;
+          const publicKey = partialSig.pubkey;
+
+          // Create ScriptWitnessV0 objects
+          const signatureWitness = new ScriptWitnessV0();
+          signatureWitness.witness = signature;
+          signatureWitness.length = signature.length;
+
+          const publicKeyWitness = new ScriptWitnessV0();
+          publicKeyWitness.witness = publicKey;
+          publicKeyWitness.length = publicKey.length;
+
+          witnessElements.push([signatureWitness, publicKeyWitness]);
+        }
+      }
+
+      fundingSignatures.witnessElements = witnessElements as any;
+      dlcSign.fundingSignatures = fundingSignatures;
+
+      // Extract refund transaction signature
+      const signedRefundPsbt = Psbt.fromBase64(signResult.refundTransaction);
+      const refundInput = signedRefundPsbt.data.inputs[0];
+      if (refundInput?.partialSig && refundInput.partialSig.length > 0) {
+        const partialSig = refundInput.partialSig[0];
+
+        // Convert DER signature to compact format (64 bytes)
+        const compactSignature = this.ensureCompactSignature(
+          partialSig.signature,
+        );
+
+        dlcSign.refundSignature = compactSignature;
+      } else {
+        throw new Error('No refund signature found in signed PSBT');
+      }
+
+      // Extract CET adaptor signatures
+      // DDK's createCetAdaptorSigsFromOracleInfo returns:
+      // { signature: 162 bytes (full adaptor sig including DLEQ proof), proof: 0 bytes }
+      // We store the full 162 bytes in encryptedSig to match DDK provider format
+      const cetAdaptorSignatures = new CetAdaptorSignatures();
+      const cetSigs: any[] = [];
+
+      for (let i = 0; i < signResult.cetTransactions.length; i++) {
+        const base64AdaptorSig = signResult.cetTransactions[i];
+        const adaptorSignature = Buffer.from(base64AdaptorSig, 'base64');
+
+        // Store the full adaptor signature in encryptedSig (matching DDK provider format)
+        // The 162-byte signature contains both the encrypted sig and DLEQ proof
+        cetSigs.push({
+          encryptedSig: adaptorSignature, // Full 162 bytes
+          dleqProof: Buffer.alloc(0), // Empty, proof is included in encryptedSig
+        });
+      }
+
+      (cetAdaptorSignatures as any).sigs = cetSigs;
+      dlcSign.cetAdaptorSignatures = cetAdaptorSignatures;
+
+      dlcSign.validate();
+
+      return { dlcSign, dlcTransactions };
+    } catch (error: unknown) {
+      const errorMessage =
+        error instanceof Error ? error.message : 'Unknown error';
+      throw new Error(`Failed to sign DLC accept: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * Detect if signature is in DER format and convert to compact format (64 bytes)
+   */
+  private ensureCompactSignature(signature: Buffer): Buffer {
+    if (signature.length === 64) {
+      return signature;
+    }
+
+    if (signature.length > 6 && signature[0] === 0x30) {
+      let derSig = signature;
+
+      // Remove SIGHASH flag if present
+      if (signature[signature.length - 1] === 0x01) {
+        derSig = signature.slice(0, -1);
+      }
+
+      if (derSig[0] !== 0x30) {
+        throw new Error('Invalid DER signature: missing SEQUENCE tag');
+      }
+
+      const totalLength = derSig[1];
+      if (derSig.length < totalLength + 2) {
+        throw new Error('Invalid DER signature: length mismatch');
+      }
+
+      let offset = 2;
+
+      // Parse R value
+      if (derSig[offset] !== 0x02) {
+        throw new Error('Invalid DER signature: missing INTEGER tag for R');
+      }
+      offset++;
+
+      const rLength = derSig[offset];
+      offset++;
+
+      if (offset + rLength > derSig.length) {
+        throw new Error(
+          'Invalid DER signature: R length exceeds signature length',
+        );
+      }
+
+      let rBytes = derSig.slice(offset, offset + rLength);
+      offset += rLength;
+
+      // Parse S value
+      if (derSig[offset] !== 0x02) {
+        throw new Error('Invalid DER signature: missing INTEGER tag for S');
+      }
+      offset++;
+
+      const sLength = derSig[offset];
+      offset++;
+
+      if (offset + sLength > derSig.length) {
+        throw new Error(
+          'Invalid DER signature: S length exceeds signature length',
+        );
+      }
+
+      let sBytes = derSig.slice(offset, offset + sLength);
+
+      // Remove leading zero padding
+      while (rBytes.length > 1 && rBytes[0] === 0x00) {
+        rBytes = rBytes.slice(1);
+      }
+      while (sBytes.length > 1 && sBytes[0] === 0x00) {
+        sBytes = sBytes.slice(1);
+      }
+
+      // Pad to 32 bytes each
+      while (rBytes.length < 32) {
+        rBytes = Buffer.concat([Buffer.from([0x00]), rBytes]);
+      }
+      while (sBytes.length < 32) {
+        sBytes = Buffer.concat([Buffer.from([0x00]), sBytes]);
+      }
+
+      if (rBytes.length !== 32 || sBytes.length !== 32) {
+        throw new Error('Invalid signature values: r or s exceeds 32 bytes');
+      }
+
+      return Buffer.concat([rBytes, sBytes]);
+    }
+
+    throw new Error(
+      'Unable to convert signature to compact format: unknown format',
+    );
+  }
+
+  /**
+   * Create refund PSBT for signing
+   */
+  private createRefundPsbt(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTransactions: DlcTransactions,
+  ): Psbt {
+    const transaction = btTransaction.fromBuffer(
+      dlcTransactions.refundTx.serialize(),
+    );
+    const refundPsbt = new Psbt({ network: this.network });
+
+    // Create the funding script (2-of-2 multisig)
+    const fundingPubKeys =
+      Buffer.compare(dlcOffer.fundingPubkey, dlcAccept.fundingPubkey) === -1
+        ? [dlcOffer.fundingPubkey, dlcAccept.fundingPubkey]
+        : [dlcAccept.fundingPubkey, dlcOffer.fundingPubkey];
+
+    const p2ms = payments.p2ms({
+      m: 2,
+      pubkeys: fundingPubKeys,
+      network: this.network,
+    });
+
+    const paymentVariant = payments.p2wsh({
+      redeem: p2ms,
+      network: this.network,
+    });
+
+    // Get the actual funding output value from the funding transaction
+    const fundingTransaction = btTransaction.fromBuffer(
+      dlcTransactions.fundTx.serialize(),
+    );
+    const actualFundingOutputValue =
+      fundingTransaction.outs[dlcTransactions.fundTxVout].value;
+
+    // Use the input hash directly from the raw refund transaction
+    const rawRefundInputHash = transaction.ins[0].hash;
+    const rawRefundInputIndex = transaction.ins[0].index;
+
+    // Add the funding input
+    refundPsbt.addInput({
+      hash: rawRefundInputHash,
+      index: rawRefundInputIndex,
+      sequence: Number(dlcTransactions.refundTx.inputs[0].sequence),
+      witnessUtxo: {
+        script: paymentVariant.output!,
+        value: actualFundingOutputValue,
+      },
+      witnessScript: paymentVariant.redeem!.output,
+    });
+
+    // Add refund outputs
+    for (const output of transaction.outs) {
+      refundPsbt.addOutput({
+        address: address.fromOutputScript(output.script, this.network),
+        value: output.value,
+      });
+    }
+
+    // Set locktime
+    refundPsbt.setLocktime(Number(dlcTransactions.refundTx.locktime));
+
+    return refundPsbt;
+  }
+
+  /**
+   * Create funding PSBT for signing
+   */
+  private createFundingPsbt(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTransactions: DlcTransactions,
+  ): Psbt {
+    const transaction = btTransaction.fromBuffer(
+      Buffer.from(dlcTransactions.fundTx.serialize()),
+    );
+    const fundingPsbt = new Psbt({ network: this.network });
+
+    // Combine all funding inputs from both parties
+    const allFundingInputs = [
+      ...dlcOffer.fundingInputs,
+      ...dlcAccept.fundingInputs,
+    ];
+
+    // Sort by inputSerialId to reconstruct proper transaction order
+    allFundingInputs.sort(
+      (a, b) => Number(a.inputSerialId) - Number(b.inputSerialId),
+    );
+
+    // Add all inputs to PSBT with proper witnessUtxo
+    for (const fundingInput of allFundingInputs) {
+      const prevOut = fundingInput.prevTx.outputs[fundingInput.prevTxVout];
+
+      const witnessUtxo = {
+        script: Buffer.from(prevOut.scriptPubKey.serialize().subarray(1)),
+        value: Number(prevOut.value.sats),
+      };
+
+      // Use sequence from the original transaction
+      const originalInput = transaction.ins.find(
+        (input) =>
+          input.hash.reverse().toString('hex') ===
+            fundingInput.prevTx.txId.toString() &&
+          input.index === fundingInput.prevTxVout,
+      );
+      const sequenceValue = originalInput
+        ? originalInput.sequence
+        : Number(fundingInput.sequence);
+
+      fundingPsbt.addInput({
+        hash: fundingInput.prevTx.txId.toString(),
+        index: fundingInput.prevTxVout,
+        sequence: sequenceValue,
+        witnessUtxo,
+      });
+    }
+
+    // Add all outputs to PSBT
+    for (const output of transaction.outs) {
+      fundingPsbt.addOutput({
+        address: address.fromOutputScript(
+          Buffer.from(output.script),
+          this.network,
+        ),
+        value: output.value,
+      });
+    }
+
+    // Set locktime
+    fundingPsbt.setLocktime(transaction.locktime);
+
+    return fundingPsbt;
+  }
+
+  /**
+   * Create CET PSBT for signing
+   */
+  private createCetPsbt(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTransactions: DlcTransactions,
+    cetIndex: number,
+  ): Psbt {
+    if (!dlcTransactions.cets || cetIndex >= dlcTransactions.cets.length) {
+      throw new Error(`CET at index ${cetIndex} not found in DLC transactions`);
+    }
+
+    const cetTransaction = dlcTransactions.cets[cetIndex];
+    const transaction = btTransaction.fromBuffer(cetTransaction.serialize());
+    const cetPsbt = new Psbt({ network: this.network });
+
+    // Create the funding script (2-of-2 multisig)
+    const fundingPubKeys =
+      Buffer.compare(dlcOffer.fundingPubkey, dlcAccept.fundingPubkey) === -1
+        ? [dlcOffer.fundingPubkey, dlcAccept.fundingPubkey]
+        : [dlcAccept.fundingPubkey, dlcOffer.fundingPubkey];
+
+    const p2ms = payments.p2ms({
+      m: 2,
+      pubkeys: fundingPubKeys,
+      network: this.network,
+    });
+
+    const paymentVariant = payments.p2wsh({
+      redeem: p2ms,
+      network: this.network,
+    });
+
+    // Get the actual funding output value from the funding transaction
+    const fundingTransaction = btTransaction.fromBuffer(
+      dlcTransactions.fundTx.serialize(),
+    );
+    const actualFundingOutputValue =
+      fundingTransaction.outs[dlcTransactions.fundTxVout].value;
+
+    // Use the input hash directly from the raw CET transaction
+    const rawCetInputHash = transaction.ins[0].hash;
+    const rawCetInputIndex = transaction.ins[0].index;
+
+    // Add the funding input
+    cetPsbt.addInput({
+      hash: rawCetInputHash,
+      index: rawCetInputIndex,
+      sequence: Number(cetTransaction.inputs[0].sequence),
+      witnessUtxo: {
+        script: paymentVariant.output!,
+        value: actualFundingOutputValue,
+      },
+      witnessScript: paymentVariant.redeem!.output,
+    });
+
+    // Add CET outputs
+    for (const output of transaction.outs) {
+      cetPsbt.addOutput({
+        address: address.fromOutputScript(output.script, this.network),
+        value: output.value,
+      });
+    }
+
+    // Set locktime if present
+    if (cetTransaction.locktime) {
+      cetPsbt.setLocktime(Number(cetTransaction.locktime));
+    }
+
+    return cetPsbt;
+  }
+
+  /**
+   * Sign a CET for execution
+   * Returns the ECDSA signature that can be combined with the decrypted adaptor sig
+   */
+  async signCetForExecution(
+    dlcOffer: DlcOffer,
+    dlcAccept: DlcAccept,
+    dlcTransactions: DlcTransactions,
+    outcomeIndex: number,
+  ): Promise<Buffer> {
+    // Create CET PSBT
+    const cetPsbt = this.createCetPsbt(
+      dlcOffer,
+      dlcAccept,
+      dlcTransactions,
+      outcomeIndex,
+    );
+
+    // Get payment address for signing
+    const paymentAddress = await this.getPaymentAddress();
+
+    // Call wallet signPsbt
+    const signResponse = await this.wallet.request<{ psbt: string }>(
+      'signPsbt',
+      {
+        psbt: cetPsbt.toBase64(),
+        signInputs: {
+          [paymentAddress.address]: [0],
+        },
+      },
+    );
+
+    if (signResponse.status === 'error') {
+      throw new Error(
+        `Failed to sign CET: ${signResponse.error?.message ?? 'Unknown error'}`,
+      );
+    }
+
+    if (!signResponse.result?.psbt) {
+      throw new Error('No signed PSBT in response');
+    }
+
+    // Extract signature from signed PSBT
+    const signedPsbt = Psbt.fromBase64(signResponse.result.psbt);
+    const input = signedPsbt.data.inputs[0];
+
+    if (!input?.partialSig || input.partialSig.length === 0) {
+      throw new Error('No signature found in signed PSBT');
+    }
+
+    const signature = input.partialSig[0].signature;
+
+    return signature;
+  }
+}
+
+export default BitcoinSatsConnectProvider;

--- a/packages/bitcoin-sats-connect-provider/lib/FordefiWalletEmulator.ts
+++ b/packages/bitcoin-sats-connect-provider/lib/FordefiWalletEmulator.ts
@@ -1,0 +1,319 @@
+import { AdaptorSignature, DdkInterface } from '@atomicfinance/types';
+import * as ecc from '@bitcoin-js/tiny-secp256k1-asmjs';
+import { fromSeed } from 'bip32';
+import { mnemonicToSeedSync } from 'bip39';
+import { BitcoinNetwork } from 'bitcoin-network';
+import { payments, Psbt } from 'bitcoinjs-lib';
+import { ECPairFactory, ECPairInterface } from 'ecpair';
+
+import {
+  AddressPurpose,
+  DlcSignOfferResult,
+  EmulatorDlcSignOfferParams,
+  SatsConnectResponse,
+  SatsConnectWalletAddress,
+  WalletInterface,
+} from './types';
+
+const ECPair = ECPairFactory(ecc);
+
+interface FordefiWalletEmulatorOptions {
+  network: BitcoinNetwork;
+  ddk: DdkInterface; // DDK instance for adaptor signature creation
+  // Either provide a privateKey directly...
+  privateKey?: string; // Hex format (64 chars) or WIF format
+  // ...or provide mnemonic + derivation path for HD wallet
+  mnemonic?: string;
+  baseDerivationPath?: string; // e.g., "m/84'/0'/0'"
+}
+
+/**
+ * Emulates Fordefi wallet's dlc_signOffer functionality locally using DDK.
+ * This allows testing DLC flows without needing an actual Fordefi wallet.
+ *
+ * The emulator implements:
+ * - getAddresses: Returns wallet addresses
+ * - dlc_signOffer: Signs funding, refund, and creates CET adaptor signatures using DDK
+ * - signPsbt: Standard PSBT signing
+ */
+export class FordefiWalletEmulator implements WalletInterface {
+  private _keyPair: ECPairInterface;
+  private _network: BitcoinNetwork;
+  private _address: string;
+  private _publicKey: Buffer;
+  private _ddk: DdkInterface;
+
+  constructor(options: FordefiWalletEmulatorOptions) {
+    const { network, privateKey, mnemonic, baseDerivationPath, ddk } = options;
+    this._network = network;
+    this._ddk = ddk;
+
+    // Initialize key pair from either privateKey or mnemonic
+    if (privateKey) {
+      // Parse private key (hex or WIF format)
+      this._keyPair = this._parsePrivateKey(privateKey, network);
+    } else if (mnemonic && baseDerivationPath) {
+      // Derive key from mnemonic
+      this._keyPair = this._deriveKeyFromMnemonic(
+        mnemonic,
+        baseDerivationPath,
+        network,
+      );
+    } else {
+      throw new Error(
+        'Either privateKey or (mnemonic + baseDerivationPath) must be provided',
+      );
+    }
+
+    this._publicKey = this._keyPair.publicKey;
+
+    // Generate P2WPKH address
+    const p2wpkh = payments.p2wpkh({
+      pubkey: this._publicKey,
+      network: this._network,
+    });
+    this._address = p2wpkh.address!;
+  }
+
+  /**
+   * Derives a key pair from a mnemonic at the first receive address (index 0)
+   */
+  private _deriveKeyFromMnemonic(
+    mnemonic: string,
+    baseDerivationPath: string,
+    network: BitcoinNetwork,
+  ): ECPairInterface {
+    const seed = mnemonicToSeedSync(mnemonic);
+    const root = fromSeed(seed, network);
+    // Derive to the first receive address: baseDerivationPath/0/0
+    const child = root.derivePath(`${baseDerivationPath}/0/0`);
+
+    if (!child.privateKey) {
+      throw new Error('Failed to derive private key from mnemonic');
+    }
+
+    return ECPair.fromPrivateKey(child.privateKey, { network });
+  }
+
+  private _parsePrivateKey(
+    privateKey: string,
+    network: BitcoinNetwork,
+  ): ECPairInterface {
+    // Check if WIF format (starts with 5, K, L, c, or 9 and is ~52 chars)
+    if (
+      privateKey.length >= 51 &&
+      privateKey.length <= 52 &&
+      /^[5KLc9]/.test(privateKey)
+    ) {
+      return ECPair.fromWIF(privateKey, network);
+    }
+
+    // Otherwise treat as hex (with or without 0x prefix)
+    let hexKey = privateKey;
+    if (hexKey.startsWith('0x')) {
+      hexKey = hexKey.slice(2);
+    }
+
+    if (hexKey.length !== 64) {
+      throw new Error(
+        'Private key must be 64 hex characters or valid WIF format',
+      );
+    }
+
+    return ECPair.fromPrivateKey(Buffer.from(hexKey, 'hex'), { network });
+  }
+
+  /**
+   * Main request handler that routes to appropriate methods
+   */
+  async request<T>(
+    method: string,
+    params?: unknown,
+  ): Promise<SatsConnectResponse<T>> {
+    try {
+      switch (method) {
+        case 'getAddresses':
+          return this._getAddresses() as SatsConnectResponse<T>;
+
+        case 'dlc_signOffer':
+          return (await this._dlcSignOffer(
+            params as EmulatorDlcSignOfferParams,
+          )) as SatsConnectResponse<T>;
+
+        case 'signPsbt':
+          return (await this._signPsbt(
+            params as { psbt: string; signInputs: Record<string, number[]> },
+          )) as SatsConnectResponse<T>;
+
+        case 'wallet_getAccount':
+          return {
+            status: 'success',
+            result: { connected: true } as T,
+          };
+
+        default:
+          return {
+            status: 'error',
+            error: {
+              code: -1,
+              message: `Unknown method: ${method}`,
+            },
+          };
+      }
+    } catch (error) {
+      return {
+        status: 'error',
+        error: {
+          code: -1,
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      };
+    }
+  }
+
+  /**
+   * Returns wallet addresses (Payment and Ordinals both point to same address for simplicity)
+   */
+  private _getAddresses(): SatsConnectResponse<{
+    addresses: SatsConnectWalletAddress[];
+  }> {
+    const addresses: SatsConnectWalletAddress[] = [
+      {
+        address: this._address,
+        publicKey: this._publicKey.toString('hex'),
+        purpose: AddressPurpose.Payment,
+        addressType: 'p2wpkh',
+      },
+      {
+        address: this._address,
+        publicKey: this._publicKey.toString('hex'),
+        purpose: AddressPurpose.Ordinals,
+        addressType: 'p2wpkh',
+      },
+    ];
+
+    return {
+      status: 'success',
+      result: { addresses },
+    };
+  }
+
+  /**
+   * Signs a PSBT with the wallet's private key
+   */
+  private async _signPsbt(params: {
+    psbt: string;
+    signInputs: Record<string, number[]>;
+  }): Promise<SatsConnectResponse<{ psbt: string }>> {
+    const psbt = Psbt.fromBase64(params.psbt, { network: this._network });
+
+    // Get the input indexes we should sign
+    const inputIndexes = params.signInputs[this._address] || [];
+
+    for (const inputIndex of inputIndexes) {
+      psbt.signInput(inputIndex, this._keyPair);
+    }
+
+    return {
+      status: 'success',
+      result: { psbt: psbt.toBase64() },
+    };
+  }
+
+  /**
+   * Implements Fordefi's dlc_signOffer method:
+   * - Signs funding transaction inputs
+   * - Signs refund transaction (multisig input)
+   * - Creates adaptor signatures for all CETs using DDK
+   *
+   * Returns:
+   * - fundingTransaction: Base64 signed PSBT
+   * - refundTransaction: Base64 signed PSBT
+   * - cetTransactions: Array of Base64 adaptor signatures
+   */
+  private async _dlcSignOffer(
+    params: EmulatorDlcSignOfferParams,
+  ): Promise<SatsConnectResponse<DlcSignOfferResult>> {
+    // Validate required DDK params
+    if (
+      !params.cets ||
+      !params.oracleInfo ||
+      !params.fundingScriptPubkey ||
+      params.fundOutputValue === undefined ||
+      !params.messages
+    ) {
+      throw new Error(
+        'Missing required DDK params (cets, oracleInfo, fundingScriptPubkey, fundOutputValue, messages)',
+      );
+    }
+
+    // 1. Sign funding transaction
+    const fundingPsbt = Psbt.fromBase64(params.fundingTransaction.psbt, {
+      network: this._network,
+    });
+    const fundingInputIndexes =
+      params.fundingTransaction.signInputs?.[this._address] || [];
+
+    for (const inputIndex of fundingInputIndexes) {
+      fundingPsbt.signInput(inputIndex, this._keyPair);
+    }
+
+    // 2. Sign refund transaction
+    const refundPsbt = Psbt.fromBase64(params.refundTransaction.psbt, {
+      network: this._network,
+    });
+    const refundInputIndexes = params.refundTransaction.signInputs?.[
+      this._address
+    ] || [0];
+
+    for (const inputIndex of refundInputIndexes) {
+      refundPsbt.signInput(inputIndex, this._keyPair);
+    }
+
+    // 3. Create adaptor signatures for CETs using DDK
+    const adaptorSigs: AdaptorSignature[] =
+      this._ddk.createCetAdaptorSigsFromOracleInfo(
+        params.cets,
+        params.oracleInfo,
+        this._keyPair.privateKey!,
+        params.fundingScriptPubkey,
+        params.fundOutputValue,
+        params.messages,
+      );
+
+    // Convert adaptor signatures to base64 format
+    // DDK returns { signature: Buffer, proof: Buffer }
+    // We concatenate signature + proof and base64 encode
+    const cetAdaptorSignatures: string[] = adaptorSigs.map((adaptorSig) => {
+      // Store encryptedSig (signature) and dleqProof (proof) separately as JSON
+      // This matches how BitcoinSatsConnectProvider expects to receive them
+      const combined = Buffer.concat([adaptorSig.signature, adaptorSig.proof]);
+      return combined.toString('base64');
+    });
+
+    return {
+      status: 'success',
+      result: {
+        fundingTransaction: fundingPsbt.toBase64(),
+        refundTransaction: refundPsbt.toBase64(),
+        cetTransactions: cetAdaptorSignatures,
+      },
+    };
+  }
+
+  /**
+   * Get the wallet's address
+   */
+  getAddress(): string {
+    return this._address;
+  }
+
+  /**
+   * Get the wallet's public key
+   */
+  getPublicKey(): Buffer {
+    return this._publicKey;
+  }
+}
+
+export default FordefiWalletEmulator;

--- a/packages/bitcoin-sats-connect-provider/lib/index.ts
+++ b/packages/bitcoin-sats-connect-provider/lib/index.ts
@@ -1,0 +1,6 @@
+import BitcoinSatsConnectProvider from './BitcoinSatsConnectProvider';
+import FordefiWalletEmulator from './FordefiWalletEmulator';
+
+export { BitcoinSatsConnectProvider, FordefiWalletEmulator };
+
+export * from './types';

--- a/packages/bitcoin-sats-connect-provider/lib/types.ts
+++ b/packages/bitcoin-sats-connect-provider/lib/types.ts
@@ -1,0 +1,99 @@
+import {
+  Address,
+  DdkInterface,
+  DdkOracleInfo,
+  DdkTransaction,
+} from '@atomicfinance/types';
+
+// DDK types re-exported for convenience
+export type { DdkInterface, DdkOracleInfo, DdkTransaction };
+
+// Additional types we need
+export interface Input {
+  txid: string;
+  vout: number;
+  address: string;
+  value: number;
+  txHex?: string; // Full transaction hex needed for DDK
+  derivationPath?: string;
+}
+
+// Address purposes (matching sats-connect)
+export enum AddressPurpose {
+  Payment = 'payment',
+  Ordinals = 'ordinals',
+}
+
+// Extended Address interface for our provider
+export interface SatsConnectAddress extends Address {
+  purpose?: AddressPurpose;
+}
+
+// SatsConnect response type
+export interface SatsConnectResponse<T> {
+  status: 'success' | 'error';
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+// DLC Sign result interface
+export interface SignDlcResult {
+  fundingTransaction: string;
+  refundTransaction: string;
+  cetTransactions: string[];
+}
+
+export interface SatsConnectWalletAddress {
+  address: string;
+  publicKey: string;
+  purpose: AddressPurpose;
+  addressType?: string;
+  derivationPath?: string;
+}
+
+export interface BitcoinSatsConnectProviderOptions {
+  esploraUrl?: string;
+  network?: import('bitcoin-network').BitcoinNetwork;
+  wallet?: WalletInterface;
+}
+
+// Wallet interface that both SatsConnect and our emulator implement
+export interface WalletInterface {
+  request<T>(method: string, params?: unknown): Promise<SatsConnectResponse<T>>;
+}
+
+// DLC Sign Offer parameters (matches Fordefi's dlc_signOffer interface)
+export interface DlcSignOfferParams {
+  fundingTransaction: {
+    psbt: string;
+    signInputs?: Record<string, number[]>;
+  };
+  refundTransaction: {
+    psbt: string;
+    signInputs?: Record<string, number[]>;
+  };
+  cetTransactions: Array<{
+    psbt: string;
+    adaptorPoint: string; // Base64-encoded 33-byte compressed SEC1 point
+  }>;
+}
+
+// Extended params for FordefiWalletEmulator (includes DDK data for local adaptor sig creation)
+export interface EmulatorDlcSignOfferParams extends DlcSignOfferParams {
+  // DDK-specific data needed by emulator to create adaptor signatures locally
+  cets: DdkTransaction[];
+  oracleInfo: DdkOracleInfo[];
+  fundingScriptPubkey: Buffer;
+  fundOutputValue: bigint;
+  messages: Buffer[][][];
+}
+
+// Response from dlc_signOffer
+export interface DlcSignOfferResult {
+  fundingTransaction: string; // Base64 signed PSBT
+  refundTransaction: string; // Base64 signed PSBT
+  cetTransactions: string[]; // Base64 adaptor signatures
+}

--- a/packages/bitcoin-sats-connect-provider/package.json
+++ b/packages/bitcoin-sats-connect-provider/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@atomicfinance/bitcoin-sats-connect-provider",
+  "version": "4.2.7",
+  "description": "Bitcoin SatsConnect Provider for DLC operations with wallet emulator",
+  "module": "dist/index.js",
+  "main": "dist/index.js",
+  "directories": {
+    "dist": "dist",
+    "src": "lib"
+  },
+  "files": [
+    "dist",
+    "lib"
+  ],
+  "scripts": {
+    "build": "../../node_modules/.bin/tsc --project tsconfig.json",
+    "lint": "../../node_modules/.bin/eslint  .",
+    "lint:fix": "../../node_modules/.bin/eslint --fix  .",
+    "test": "../../node_modules/.bin/nyc --reporter=lcov --reporter=text --extension=.ts ../../node_modules/.bin/mocha --recursive \"tests/**/*.test.*\""
+  },
+  "author": "Atomic Finance <info@atomic.finance>",
+  "license": "MIT",
+  "engines": {
+    "node": ">=14"
+  },
+  "dependencies": {
+    "@atomicfinance/bitcoin-utils": "^4.2.7",
+    "@atomicfinance/bitcoin-wallet-provider": "^4.2.7",
+    "@atomicfinance/provider": "^4.2.7",
+    "@atomicfinance/types": "^4.2.7",
+    "@atomicfinance/utils": "^4.2.7",
+    "@babel/runtime": "^7.12.1",
+    "@node-dlc/core": "1.1.7",
+    "@node-dlc/messaging": "1.1.7",
+    "bip32": "^2.0.6",
+    "bip39": "^3.0.2",
+    "bitcoin-network": "0.1.0",
+    "bitcoinjs-lib": "6.1.7",
+    "bitcoinjs-message": "^2.1.0",
+    "ecpair": "^2.1.0",
+    "@bitcoin-js/tiny-secp256k1-asmjs": "^2.2.0",
+    "@node-dlc/bufio": "1.1.7"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "sideEffects": false,
+  "devDependencies": {
+    "@types/node": "^20.0.0"
+  }
+}

--- a/packages/bitcoin-sats-connect-provider/tsconfig.json
+++ b/packages/bitcoin-sats-connect-provider/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+  },
+  "include": ["./lib"],
+}

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -169,13 +169,19 @@ export default class Dlc implements DlcProvider {
    * Sign Dlc Accept Message
    * @param dlcOffer Dlc Offer Message
    * @param dlcAccept Dlc Accept Message
+   * @param dlcTransactions Optional Dlc Transactions (required for SatsConnectProvider)
    * @returns {Promise<SignDlcAcceptResponse}
    */
   async signDlcAccept(
     dlcOffer: DlcOffer,
     dlcAccept: DlcAccept,
+    dlcTransactions?: DlcTransactions,
   ): Promise<SignDlcAcceptResponse> {
-    return this.client.getMethod('signDlcAccept')(dlcOffer, dlcAccept);
+    return this.client.getMethod('signDlcAccept')(
+      dlcOffer,
+      dlcAccept,
+      dlcTransactions,
+    );
   }
 
   /**

--- a/packages/types/lib/ddk.ts
+++ b/packages/types/lib/ddk.ts
@@ -39,6 +39,15 @@ export interface DdkOracleInfo {
   nonces: Array<Buffer>;
 }
 
+export interface CetAdaptorSignatureInputs {
+  cetTxid: string;
+  sighash: Buffer;
+  adaptorPoint: Buffer;
+  inputIndex: number;
+  scriptPubkey: Buffer;
+  value: bigint;
+}
+
 export interface PartyParams {
   fundPubkey: Buffer;
   changeScriptPubkey: Buffer;
@@ -114,6 +123,11 @@ export interface DdkInterface {
     fundOutputValue: bigint,
     msgs: Array<Array<Array<Buffer>>>,
   ): Array<AdaptorSignature>;
+
+  createCetAdaptorPointsFromOracleInfo(
+    oracleInfo: Array<DdkOracleInfo>,
+    msgs: Array<Array<Array<Buffer>>>,
+  ): Array<Buffer>;
 
   verifyCetAdaptorSigFromOracleInfo(
     adaptorSig: AdaptorSignature,
@@ -259,6 +273,21 @@ export interface DdkInterface {
     localPrivkey: Buffer,
     remoteSignature: Buffer,
   ): DdkTransaction;
+
+  // Debug methods for CET adaptor signature verification
+  getCetAdaptorSignatureInputs(
+    cet: DdkTransaction,
+    oracleInfo: Array<DdkOracleInfo>,
+    fundingScriptPubkey: Buffer,
+    fundOutputValue: bigint,
+    msgs: Array<Array<Buffer>>,
+  ): CetAdaptorSignatureInputs;
+
+  getCetSighash(
+    cet: DdkTransaction,
+    fundingScriptPubkey: Buffer,
+    fundOutputValue: bigint,
+  ): Buffer;
 }
 
 // Legacy function declarations for backward compatibility
@@ -451,3 +480,18 @@ export declare function signMultiSigInput(
   localPrivkey: Buffer,
   remoteSignature: Buffer,
 ): DdkTransaction;
+
+// Debug methods for CET adaptor signature verification
+export declare function getCetAdaptorSignatureInputs(
+  cet: DdkTransaction,
+  oracleInfo: Array<DdkOracleInfo>,
+  fundingScriptPubkey: Buffer,
+  fundOutputValue: bigint,
+  msgs: Array<Array<Buffer>>,
+): CetAdaptorSignatureInputs;
+
+export declare function getCetSighash(
+  cet: DdkTransaction,
+  fundingScriptPubkey: Buffer,
+  fundOutputValue: bigint,
+): Buffer;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -589,6 +589,9 @@ importers:
       '@bitcoin-js/tiny-secp256k1-asmjs':
         specifier: ^2.2.0
         version: 2.2.4
+      '@node-dlc/bufio':
+        specifier: 1.1.7
+        version: 1.1.7
       '@node-dlc/core':
         specifier: 1.1.7
         version: 1.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     devDependencies:
       '@bennyblader/ddk-ts':
-        specifier: ^0.3.31
-        version: 0.3.31
+        specifier: ^0.3.33
+        version: 0.3.33
       '@changesets/cli':
         specifier: ^2.22.0
         version: 2.29.5
@@ -181,10 +181,10 @@ importers:
   packages/bitcoin-cfd-address-derivation-provider:
     dependencies:
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       bip32:
         specifier: ^4.0.0
@@ -206,13 +206,13 @@ importers:
   packages/bitcoin-cfd-provider:
     dependencies:
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       lodash:
         specifier: ^4.17.20
@@ -228,10 +228,10 @@ importers:
   packages/bitcoin-ddk-address-derivation-provider:
     dependencies:
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       bip32:
         specifier: ^4.0.0
@@ -253,16 +253,16 @@ importers:
   packages/bitcoin-ddk-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: 4.2.6
+        specifier: 4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@bitcoin-js/tiny-secp256k1-asmjs':
         specifier: ^2.2.0
@@ -293,16 +293,16 @@ importers:
   packages/bitcoin-dlc-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: 4.2.6
+        specifier: 4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@bitcoin-js/tiny-secp256k1-asmjs':
         specifier: ^2.2.0
@@ -357,22 +357,22 @@ importers:
   packages/bitcoin-esplora-api-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/crypto':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../crypto
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/node-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../node-provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -400,16 +400,16 @@ importers:
   packages/bitcoin-esplora-batch-api-provider:
     dependencies:
       '@atomicfinance/bitcoin-esplora-api-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-esplora-api-provider
       '@atomicfinance/node-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../node-provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -434,19 +434,19 @@ importers:
   packages/bitcoin-js-wallet-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/bitcoin-wallet-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-wallet-provider
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -483,22 +483,22 @@ importers:
   packages/bitcoin-node-wallet-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/crypto':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../crypto
       '@atomicfinance/jsonrpc-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../jsonrpc-provider
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -532,19 +532,19 @@ importers:
   packages/bitcoin-rpc-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/jsonrpc-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../jsonrpc-provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -566,19 +566,71 @@ importers:
         specifier: ^20.0.0
         version: 20.19.10
 
+  packages/bitcoin-sats-connect-provider:
+    dependencies:
+      '@atomicfinance/bitcoin-utils':
+        specifier: ^4.2.7
+        version: link:../bitcoin-utils
+      '@atomicfinance/bitcoin-wallet-provider':
+        specifier: ^4.2.7
+        version: link:../bitcoin-wallet-provider
+      '@atomicfinance/provider':
+        specifier: ^4.2.7
+        version: link:../provider
+      '@atomicfinance/types':
+        specifier: ^4.2.7
+        version: link:../types
+      '@atomicfinance/utils':
+        specifier: ^4.2.7
+        version: link:../utils
+      '@babel/runtime':
+        specifier: ^7.12.1
+        version: 7.28.2
+      '@bitcoin-js/tiny-secp256k1-asmjs':
+        specifier: ^2.2.0
+        version: 2.2.4
+      '@node-dlc/core':
+        specifier: 1.1.7
+        version: 1.1.7
+      '@node-dlc/messaging':
+        specifier: 1.1.7
+        version: 1.1.7
+      bip32:
+        specifier: ^2.0.6
+        version: 2.0.6
+      bip39:
+        specifier: ^3.0.2
+        version: 3.1.0
+      bitcoin-network:
+        specifier: 0.1.0
+        version: 0.1.0
+      bitcoinjs-lib:
+        specifier: 6.1.7
+        version: 6.1.7
+      bitcoinjs-message:
+        specifier: ^2.1.0
+        version: 2.2.0
+      ecpair:
+        specifier: ^2.1.0
+        version: 2.1.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.10
+
   packages/bitcoin-utils:
     dependencies:
       '@atomicfinance/crypto':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../crypto
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@babel/runtime':
         specifier: ^7.12.1
@@ -612,19 +664,19 @@ importers:
   packages/bitcoin-wallet-provider:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@atomicfinance/utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../utils
       '@node-dlc/core':
         specifier: 1.1.7
@@ -655,16 +707,16 @@ importers:
   packages/client:
     dependencies:
       '@atomicfinance/bitcoin-utils':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../bitcoin-utils
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@node-dlc/bitcoin':
         specifier: 1.1.7
@@ -717,10 +769,10 @@ importers:
   packages/jsonrpc-provider:
     dependencies:
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/node-provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../node-provider
       '@babel/runtime':
         specifier: ^7.12.1
@@ -745,10 +797,10 @@ importers:
   packages/node-provider:
     dependencies:
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/provider':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../provider
       '@babel/runtime':
         specifier: ^7.12.1
@@ -770,7 +822,7 @@ importers:
   packages/provider:
     dependencies:
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       lodash:
         specifier: ^4.17.20
@@ -808,13 +860,13 @@ importers:
   packages/utils:
     dependencies:
       '@atomicfinance/crypto':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../crypto
       '@atomicfinance/errors':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../errors
       '@atomicfinance/types':
-        specifier: ^4.2.6
+        specifier: ^4.2.7
         version: link:../types
       '@babel/runtime':
         specifier: ^7.12.1
@@ -1010,8 +1062,8 @@ packages:
       '@babel/helper-validator-identifier': 7.27.1
     dev: true
 
-  /@bennyblader/ddk-ts@0.3.31:
-    resolution: {integrity: sha512-juVHpJIgqoKOw/R5GjDooa8g/oEKFM43dUcSXynGRdSCkBoH1idKJqLVg2SGYLVXtfRrXcMbT4v4zm0y6KUZsg==}
+  /@bennyblader/ddk-ts@0.3.33:
+    resolution: {integrity: sha512-2s9/zsV/G8Bdunaa1cjcl2txPsbLOzn9eEE8vZqODEK+RlwKPXj8TWzLlD6tZNnSkBDafvyso/DfnnDcg3O/nA==}
     engines: {node: '>= 6.14.2 < 7 || >= 8.11.2 < 9 || >= 9.11.0 < 10 || >= 10.0.0'}
     dev: true
 

--- a/tests/integration/config.ts
+++ b/tests/integration/config.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: findConfig('.env') });
 export default {
   bitcoin: {
     rpc: {
-      host: 'http://localhost:18443/wallet/default',
+      host: 'http://localhost:18443',
       username: process.env.RPC_USER || 'admin1',
       password: process.env.RPC_PASS || '123',
     },

--- a/tests/integration/config.ts
+++ b/tests/integration/config.ts
@@ -7,7 +7,7 @@ dotenv.config({ path: findConfig('.env') });
 export default {
   bitcoin: {
     rpc: {
-      host: 'http://localhost:18443',
+      host: 'http://localhost:18443/wallet/default',
       username: process.env.RPC_USER || 'admin1',
       password: process.env.RPC_PASS || '123',
     },


### PR DESCRIPTION
## Summary

- Adds new `bitcoin-sats-connect-provider` package for integrating with SatsConnect-compatible wallets (e.g., Fordefi)
- Includes `FordefiWalletEmulator` for testing DLC flows without a real wallet
- Adds debugging utilities for CET adaptor signature verification
- Exposes `createCetAdaptorPointsFromOracleInfo` in DDK interface for generating adaptor points

## Changes

### New Package: `bitcoin-sats-connect-provider`
- `BitcoinSatsConnectProvider.ts` - Main provider implementation
- `FordefiWalletEmulator.ts` - Test emulator for Fordefi wallet interface
- `types.ts` - Type definitions for SatsConnect DLC operations

### BitcoinDdkProvider Enhancements
- `getCetAdaptorSignatureDebugInfo()` - Returns detailed info for each CET including sighash, adaptor point, and message data
- Useful for debugging adaptor signature creation/verification issues

### Type Updates
- Added `CetAdaptorSignatureInputs` interface
- Added `createCetAdaptorPointsFromOracleInfo` to `DdkInterface`
- Added `getCetAdaptorSignatureInputs` and `getCetSighash` debug methods

### Test Updates
- Extended integration tests for DLC flows with new provider

## Test plan

- [ ] Run integration tests: `pnpm test:integration`
- [ ] Verify DLC offer/accept/sign flow with emulator
- [ ] Test adaptor signature debug output matches expected values
