### PR TITLE
feat: add refundPayout override to createDlcTxs

### DIFF
--- a/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
+++ b/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
@@ -706,6 +706,7 @@ export default class BitcoinDdkProvider extends Provider {
   public async createDlcTxs(
     dlcOffer: DlcOffer,
     dlcAccept: DlcAccept,
+    options?: { offerRefundPayout?: bigint; acceptRefundPayout?: bigint },
   ): Promise<CreateDlcTxsResponse> {
     const localFundPubkey = dlcOffer.fundingPubkey.toString('hex');
     const remoteFundPubkey = dlcAccept.fundingPubkey.toString('hex');
@@ -810,6 +811,7 @@ export default class BitcoinDdkProvider extends Provider {
       inputAmount: BigInt(localInputAmount),
       collateral: BigInt(dlcOffer.offerCollateral),
       dlcInputs: localDlcInputs,
+      refundPayout: options?.offerRefundPayout,
     };
 
     const remoteParams: PartyParams = {
@@ -822,6 +824,7 @@ export default class BitcoinDdkProvider extends Provider {
       inputAmount: BigInt(remoteInputAmount),
       collateral: BigInt(dlcAccept.acceptCollateral),
       dlcInputs: [],
+      refundPayout: options?.acceptRefundPayout,
     };
 
     // Determine whether to use regular or spliced DLC transactions

--- a/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
+++ b/packages/bitcoin-dlc-provider/lib/BitcoinDlcProvider.ts
@@ -695,6 +695,7 @@ export default class BitcoinDlcProvider
   public async createDlcTxs(
     dlcOffer: DlcOffer,
     dlcAccept: DlcAccept,
+    _options?: { offerRefundPayout?: bigint; acceptRefundPayout?: bigint },
   ): Promise<CreateDlcTxsResponse> {
     const localFundPubkey = dlcOffer.fundingPubkey.toString('hex');
     const remoteFundPubkey = dlcAccept.fundingPubkey.toString('hex');

--- a/packages/client/lib/Dlc.ts
+++ b/packages/client/lib/Dlc.ts
@@ -88,8 +88,9 @@ export default class Dlc implements DlcProvider {
   async createDlcTxs(
     dlcOffer: DlcOffer,
     dlcAccept: DlcAccept,
+    options?: { offerRefundPayout?: bigint; acceptRefundPayout?: bigint },
   ): Promise<CreateDlcTxsResponse> {
-    return this.client.getMethod('createDlcTxs')(dlcOffer, dlcAccept);
+    return this.client.getMethod('createDlcTxs')(dlcOffer, dlcAccept, options);
   }
 
   /**

--- a/packages/types/lib/ddk.ts
+++ b/packages/types/lib/ddk.ts
@@ -49,6 +49,7 @@ export interface PartyParams {
   inputAmount: bigint;
   collateral: bigint;
   dlcInputs: Array<DdkDlcInputInfo>;
+  refundPayout?: bigint;
 }
 
 export interface Payout {

--- a/packages/types/lib/dlc.ts
+++ b/packages/types/lib/dlc.ts
@@ -39,6 +39,7 @@ export interface DlcProvider {
   createDlcTxs(
     _dlcOffer: DlcOffer,
     _dlcAccept: DlcAccept,
+    _options?: { offerRefundPayout?: bigint; acceptRefundPayout?: bigint },
   ): Promise<CreateDlcTxsResponse>;
 
   /**


### PR DESCRIPTION
Adds optional offerRefundPayout/acceptRefundPayout params that flow through PartyParams to the DDK, allowing custom refund TX payout amounts independent of collateral contribution.