### PR TITLE
fix: build wallet sweeps in one pass

### DIFF
--- a/.changeset/fix-wallet-sweep-fees.md
+++ b/.changeset/fix-wallet-sweep-fees.md
@@ -1,0 +1,5 @@
+---
+"@atomicfinance/bitcoin-js-wallet-provider": patch
+---
+
+Fix wallet sweep transaction construction to reserve fees from the finalized transaction shape.

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -29,6 +29,8 @@ import { signAsync as signBitcoinMessage } from 'bitcoinjs-message';
 import { ECPairInterface } from 'ecpair';
 
 const FEE_PER_BYTE_FALLBACK = 5;
+const P2WPKH_INPUT_VBYTES = 68;
+const TX_OVERHEAD_VBYTES = 10.5;
 
 type WalletProviderConstructor<T = Provider> = new (...args: unknown[]) => T;
 
@@ -606,7 +608,18 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     }
 
     const inputValue = inputs.reduce((total, input) => total + input.value, 0);
-    let fee = Math.ceil((10.5 + inputs.length * 68 + 31) * _feePerByte);
+    bitcoin.initEccLib(getEcc() as never);
+    const outputScript = bitcoin.address.toOutputScript(
+      externalChangeAddress,
+      this._network,
+    );
+    const outputVbytes = 8 + 1 + outputScript.length;
+    let fee = Math.ceil(
+      (TX_OVERHEAD_VBYTES +
+        inputs.length * P2WPKH_INPUT_VBYTES +
+        outputVbytes) *
+        _feePerByte,
+    );
     let hex = '';
 
     for (let attempt = 0; attempt < 5; attempt++) {

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -30,7 +30,10 @@ import { ECPairInterface } from 'ecpair';
 
 const FEE_PER_BYTE_FALLBACK = 5;
 const P2WPKH_INPUT_VBYTES = 68;
+const P2SH_SEGWIT_INPUT_VBYTES = 91;
+const LEGACY_INPUT_VBYTES = 148;
 const TX_OVERHEAD_VBYTES = 10.5;
+const CONSERVATIVE_DUST_THRESHOLD = 546;
 
 type WalletProviderConstructor<T = Provider> = new (...args: unknown[]) => T;
 
@@ -595,7 +598,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     let _feePerByte = feePerByte || null;
     if (!_feePerByte) _feePerByte = await this.getMethod('getFeePerByte')();
 
-    const { inputs } = await this.getInputsForAmount(
+    const { inputs, change } = await this.getInputsForAmount(
       [],
       _feePerByte,
       [],
@@ -607,6 +610,12 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       throw new Error('Not enough balance');
     }
 
+    if (change) {
+      throw new Error(
+        'There should not be any change for sweeping transaction',
+      );
+    }
+
     const inputValue = inputs.reduce((total, input) => total + input.value, 0);
     bitcoin.initEccLib(getEcc() as never);
     const outputScript = bitcoin.address.toOutputScript(
@@ -614,17 +623,21 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       this._network,
     );
     const outputVbytes = 8 + 1 + outputScript.length;
+    const inputVbytes = this._getSweepInputVbytes();
     let fee = Math.ceil(
       (TX_OVERHEAD_VBYTES +
-        inputs.length * P2WPKH_INPUT_VBYTES +
+        inputs.length * inputVbytes +
         outputVbytes) *
         _feePerByte,
     );
     let hex = '';
+    let tx: BitcoinJsTransaction;
 
     for (let attempt = 0; attempt < 5; attempt++) {
       const sendAmount = inputValue - fee;
-      if (sendAmount <= 0) throw new Error('Not enough balance');
+      if (sendAmount < CONSERVATIVE_DUST_THRESHOLD) {
+        throw new Error('Not enough balance');
+      }
 
       hex = await this._buildTransactionWithInputs(
         [
@@ -636,13 +649,24 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
         inputs as unknown as bT.UTXO[],
       );
 
-      const tx = BitcoinJsTransaction.fromHex(hex);
+      tx = BitcoinJsTransaction.fromHex(hex);
       const requiredFee = Math.ceil(tx.virtualSize() * _feePerByte);
       if (requiredFee <= fee) break;
       fee = requiredFee;
     }
 
-    return { hex, fee };
+    const finalTx = BitcoinJsTransaction.fromHex(hex);
+    return { hex, fee: inputValue - finalTx.outs[0].value };
+  }
+
+  _getSweepInputVbytes() {
+    if (this._addressType === bT.AddressType.LEGACY) {
+      return LEGACY_INPUT_VBYTES;
+    }
+    if (this._addressType === bT.AddressType.P2SH_SEGWIT) {
+      return P2SH_SEGWIT_INPUT_VBYTES;
+    }
+    return P2WPKH_INPUT_VBYTES;
   }
 
   async _buildTransactionWithInputs(

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -625,9 +625,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     const outputVbytes = 8 + 1 + outputScript.length;
     const inputVbytes = this._getSweepInputVbytes();
     let fee = Math.ceil(
-      (TX_OVERHEAD_VBYTES +
-        inputs.length * inputVbytes +
-        outputVbytes) *
+      (TX_OVERHEAD_VBYTES + inputs.length * inputVbytes + outputVbytes) *
         _feePerByte,
     );
     let hex = '';

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -593,7 +593,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     let _feePerByte = feePerByte || null;
     if (!_feePerByte) _feePerByte = await this.getMethod('getFeePerByte')();
 
-    const { inputs, outputs, change } = await this.getInputsForAmount(
+    const { inputs } = await this.getInputsForAmount(
       [],
       _feePerByte,
       [],
@@ -601,24 +601,110 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       true,
     );
 
-    if (change) {
-      throw new Error(
-        'There should not be any change for sweeping transaction',
+    if (!inputs || inputs.length === 0) {
+      throw new Error('Not enough balance');
+    }
+
+    const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+    let fee = Math.ceil((10.5 + inputs.length * 68 + 31) * _feePerByte);
+    let hex = '';
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const sendAmount = inputValue - fee;
+      if (sendAmount <= 0) throw new Error('Not enough balance');
+
+      hex = await this._buildTransactionWithInputs(
+        [
+          {
+            address: externalChangeAddress,
+            value: sendAmount,
+          },
+        ],
+        inputs as unknown as bT.UTXO[],
+      );
+
+      const tx = BitcoinJsTransaction.fromHex(hex);
+      const requiredFee = Math.ceil(tx.virtualSize() * _feePerByte);
+      if (requiredFee <= fee) break;
+      fee = requiredFee;
+    }
+
+    return { hex, fee };
+  }
+
+  async _buildTransactionWithInputs(
+    targets: bT.OutputTarget[],
+    inputs: bT.UTXO[],
+  ) {
+    const network = this._network;
+    const psbt = new Psbt({ network });
+
+    const needsWitness = [
+      bT.AddressType.BECH32,
+      bT.AddressType.P2SH_SEGWIT,
+    ].includes(this._addressType);
+
+    for (let i = 0; i < inputs.length; i++) {
+      const wallet = await this.getWalletAddress(inputs[i].address);
+      const keyPair = await this.keyPair(wallet.derivationPath);
+      const paymentVariant = this.getPaymentVariantFromPublicKey(
+        keyPair.publicKey,
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const psbtInput: any = {
+        hash: inputs[i].txid,
+        index: inputs[i].vout,
+        sequence: 0,
+      };
+
+      if (needsWitness) {
+        psbtInput.witnessUtxo = {
+          script: paymentVariant.output,
+          value: inputs[i].value,
+        };
+      } else {
+        const inputTxRaw = await this.getMethod('getRawTransactionByHash')(
+          inputs[i].txid,
+        );
+        psbtInput.nonWitnessUtxo = Buffer.from(inputTxRaw, 'hex');
+      }
+
+      if (this._addressType === bT.AddressType.P2SH_SEGWIT) {
+        psbtInput.redeemScript = paymentVariant.redeem.output;
+      }
+
+      psbt.addInput(psbtInput);
+    }
+
+    for (const output of targets) {
+      if (output.script) {
+        psbt.addOutput({
+          value: output.value,
+          script: output.script,
+        });
+      } else {
+        psbt.addOutput({
+          value: output.value,
+          address: output.address,
+        });
+      }
+    }
+
+    for (let i = 0; i < inputs.length; i++) {
+      const wallet = await this.getWalletAddress(inputs[i].address);
+      const keyPair = await this.keyPair(wallet.derivationPath);
+      psbt.signInput(i, keyPair);
+      psbt.validateSignaturesOfInput(
+        i,
+        (pubkey: Buffer, msghash: Buffer, signature: Buffer) =>
+          getEcc().verify(msghash, pubkey, signature),
       );
     }
 
-    const _outputs = [
-      {
-        address: externalChangeAddress,
-        value: outputs[0].value,
-      },
-    ];
+    psbt.finalizeAllInputs();
 
-    return this._buildTransaction(
-      _outputs,
-      feePerByte,
-      inputs as unknown as bT.Input[],
-    );
+    return psbt.extractTransaction().toHex();
   }
 
   async signPSBT(data: string, inputs: bT.PsbtInputTarget[]) {

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -81,6 +81,12 @@ describe('Bitcoin Wallet provider', () => {
     const taprootDestination =
       'bcrt1p7yu5dsly83jg5tkxcljsa30vnpdpl22wr6rty98t6x6p6ekz2gkqcckz99';
 
+    const expectFeeWithinEstimate = (fee: number, tx: Transaction) => {
+      const expectedFee = Math.ceil(tx.virtualSize() * feeRate);
+      expect(fee).to.be.at.least(expectedFee);
+      expect(fee).to.be.at.most(expectedFee + feeRate);
+    };
+
     const mockSweepInputs = async (values: number[]) => {
       const addresses = await provider.getAddresses(0, values.length);
       const inputs = addresses.map((address, index) => ({
@@ -114,7 +120,7 @@ describe('Bitcoin Wallet provider', () => {
 
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
-      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+      expectFeeWithinEstimate(fee, tx);
     });
 
     it('sweeps multiple P2WPKH inputs with no change output', async () => {
@@ -131,7 +137,7 @@ describe('Bitcoin Wallet provider', () => {
       expect(tx.ins).to.have.length(3);
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
-      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+      expectFeeWithinEstimate(fee, tx);
     });
 
     it('sweeps one P2WPKH input to a P2TR output with no change output', async () => {
@@ -147,7 +153,7 @@ describe('Bitcoin Wallet provider', () => {
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].script.length).to.equal(34);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
-      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+      expectFeeWithinEstimate(fee, tx);
     });
 
     it('sweeps multiple P2WPKH inputs to a P2TR output with no change output', async () => {
@@ -164,7 +170,7 @@ describe('Bitcoin Wallet provider', () => {
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].script.length).to.equal(34);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
-      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+      expectFeeWithinEstimate(fee, tx);
     });
 
     it('rejects P2WPKH sweeps that cannot cover fees', async () => {
@@ -174,6 +180,32 @@ describe('Bitcoin Wallet provider', () => {
       await expect(
         provider._buildSweepTransaction(destination.address, feeRate),
       ).to.eventually.be.rejectedWith('Not enough balance');
+    });
+
+    it('rejects P2WPKH sweeps with a dust output', async () => {
+      await mockSweepInputs([1500]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      await expect(
+        provider._buildSweepTransaction(destination.address, feeRate),
+      ).to.eventually.be.rejectedWith('Not enough balance');
+    });
+
+    it('rejects sweep coin selection that returns change', async () => {
+      const inputs = await mockSweepInputs([100000]);
+      const [destination] = await provider.getAddresses(10, 1);
+      provider.getInputsForAmount = async () => ({
+        inputs,
+        outputs: [],
+        change: { value: 1000 },
+        fee: 0,
+      });
+
+      await expect(
+        provider._buildSweepTransaction(destination.address, feeRate),
+      ).to.eventually.be.rejectedWith(
+        'There should not be any change for sweeping transaction',
+      );
     });
   });
 });

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -78,6 +78,8 @@ describe('Bitcoin Wallet provider', () => {
 
   describe('_buildSweepTransaction', () => {
     const feeRate = 10;
+    const taprootDestination =
+      'bcrt1p7yu5dsly83jg5tkxcljsa30vnpdpl22wr6rty98t6x6p6ekz2gkqcckz99';
 
     const mockSweepInputs = async (values: number[]) => {
       const addresses = await provider.getAddresses(0, values.length);
@@ -128,6 +130,39 @@ describe('Bitcoin Wallet provider', () => {
 
       expect(tx.ins).to.have.length(3);
       expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].value).to.equal(inputValue - fee);
+      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+    });
+
+    it('sweeps one P2WPKH input to a P2TR output with no change output', async () => {
+      const inputs = await mockSweepInputs([100000]);
+
+      const { hex, fee } = await provider._buildSweepTransaction(
+        taprootDestination,
+        feeRate,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].script.length).to.equal(34);
+      expect(tx.outs[0].value).to.equal(inputValue - fee);
+      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+    });
+
+    it('sweeps multiple P2WPKH inputs to a P2TR output with no change output', async () => {
+      const inputs = await mockSweepInputs([100000, 200000, 300000]);
+
+      const { hex, fee } = await provider._buildSweepTransaction(
+        taprootDestination,
+        feeRate,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+
+      expect(tx.ins).to.have.length(3);
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].script.length).to.equal(34);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
       expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
     });

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -1,8 +1,9 @@
 /* eslint-env mocha */
 
-import { Address } from '@atomicfinance/types/lib';
+import { Address } from '@atomicfinance/types';
 import { generateMnemonic } from 'bip39';
 import { BitcoinNetworks } from 'bitcoin-network';
+import { Transaction } from 'bitcoinjs-lib';
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 
@@ -72,6 +73,72 @@ describe('Bitcoin Wallet provider', () => {
       await expect(
         newProvider.setDerivationCache(addressesFromDerivationCacheExpected),
       ).to.eventually.be.rejected;
+    });
+  });
+
+  describe('_buildSweepTransaction', () => {
+    const feeRate = 10;
+
+    const mockSweepInputs = async (values: number[]) => {
+      const addresses = await provider.getAddresses(0, values.length);
+      const inputs = addresses.map((address, index) => ({
+        txid: Buffer.alloc(32, index + 1).toString('hex'),
+        vout: 0,
+        value: values[index],
+        address: address.address,
+        derivationPath: address.derivationPath,
+      }));
+
+      provider.getInputsForAmount = async () => ({
+        inputs,
+        outputs: [],
+        change: undefined,
+        fee: 0,
+      });
+
+      return inputs;
+    };
+
+    it('sweeps one P2WPKH input with no change output', async () => {
+      const inputs = await mockSweepInputs([100000]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      const { hex, fee } = await provider._buildSweepTransaction(
+        destination.address,
+        feeRate,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].value).to.equal(inputValue - fee);
+      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+    });
+
+    it('sweeps multiple P2WPKH inputs with no change output', async () => {
+      const inputs = await mockSweepInputs([100000, 200000, 300000]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      const { hex, fee } = await provider._buildSweepTransaction(
+        destination.address,
+        feeRate,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+
+      expect(tx.ins).to.have.length(3);
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].value).to.equal(inputValue - fee);
+      expect(fee).to.be.at.least(Math.ceil(tx.virtualSize() * feeRate));
+    });
+
+    it('rejects P2WPKH sweeps that cannot cover fees', async () => {
+      await mockSweepInputs([100]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      await expect(
+        provider._buildSweepTransaction(destination.address, feeRate),
+      ).to.eventually.be.rejectedWith('Not enough balance');
     });
   });
 });

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -116,7 +116,10 @@ describe('Bitcoin Wallet provider', () => {
         feeRate,
       );
       const tx = Transaction.fromHex(hex);
-      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+      const inputValue = inputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
 
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].value).to.equal(inputValue - fee);
@@ -132,7 +135,10 @@ describe('Bitcoin Wallet provider', () => {
         feeRate,
       );
       const tx = Transaction.fromHex(hex);
-      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+      const inputValue = inputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
 
       expect(tx.ins).to.have.length(3);
       expect(tx.outs).to.have.length(1);
@@ -148,7 +154,10 @@ describe('Bitcoin Wallet provider', () => {
         feeRate,
       );
       const tx = Transaction.fromHex(hex);
-      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+      const inputValue = inputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
 
       expect(tx.outs).to.have.length(1);
       expect(tx.outs[0].script.length).to.equal(34);
@@ -164,7 +173,10 @@ describe('Bitcoin Wallet provider', () => {
         feeRate,
       );
       const tx = Transaction.fromHex(hex);
-      const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+      const inputValue = inputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
 
       expect(tx.ins).to.have.length(3);
       expect(tx.outs).to.have.length(1);


### PR DESCRIPTION
## Summary
- Build BitcoinJs wallet sweep transactions directly from selected UTXOs instead of re-entering normal coin selection.
- Reserve P2WPKH-input sweep fees from the finalized transaction shape.
- Size destination outputs from the actual output script, including Taproot/P2TR recipient addresses.
- Add sweep regression tests for P2WPKH destinations, Taproot destinations, multiple inputs, and insufficient funds.


## Test plan
- pnpm --filter @atomicfinance/bitcoin-js-wallet-provider build
- pnpm --filter @atomicfinance/bitcoin-js-wallet-provider test