### PR TITLE
fix: DDK execute fails with InvalidSignature after message serialization round-trip

### DIFF
--- a/.changeset/tidy-lions-tell.md
+++ b/.changeset/tidy-lions-tell.md
@@ -1,0 +1,5 @@
+---
+'@atomicfinance/bitcoin-ddk-provider': patch
+---
+
+Fix execute failing with InvalidSignature after DLC messages are serialized and deserialized. @node-dlc/messaging splits the 162-byte ECDSA adaptor signature into encryptedSig (65) + dleqProof (97) on deserialize, but the signCet call sites passed encryptedSig alone; they now recombine the full adaptor signature.

--- a/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
+++ b/packages/bitcoin-ddk-provider/lib/BitcoinDdkProvider.ts
@@ -2536,6 +2536,21 @@ Payout Group not found even with brute force search',
     }
   }
 
+  /**
+   * DDK expects the full 162-byte ECDSA adaptor signature. Live message objects
+   * carry all 162 bytes in encryptedSig, but after a serialize/deserialize
+   * round-trip @node-dlc/messaging splits them into encryptedSig (65) and
+   * dleqProof (97) — recombine when needed.
+   */
+  private getFullAdaptorSig(sig: {
+    encryptedSig: Buffer;
+    dleqProof: Buffer;
+  }): Buffer {
+    return sig.dleqProof && sig.dleqProof.length > 0
+      ? Buffer.concat([sig.encryptedSig, sig.dleqProof])
+      : sig.encryptedSig;
+  }
+
   async FindAndSignCet(
     dlcOffer: DlcOffer,
     dlcAccept: DlcAccept,
@@ -2582,9 +2597,11 @@ Payout Group not found even with brute force search',
       finalCet = this._ddk
         .signCet(
           this.convertTxToDdkTransaction(dlcTxs.cets[outcomeIndex]),
-          isOfferer
-            ? dlcAccept.cetAdaptorSignatures.sigs[outcomeIndex].encryptedSig
-            : dlcSign.cetAdaptorSignatures.sigs[outcomeIndex].encryptedSig,
+          this.getFullAdaptorSig(
+            isOfferer
+              ? dlcAccept.cetAdaptorSignatures.sigs[outcomeIndex]
+              : dlcSign.cetAdaptorSignatures.sigs[outcomeIndex],
+          ),
           oracleAttestation.signatures,
           Buffer.from(fundPrivateKey, 'hex'),
           isOfferer ? dlcAccept.fundingPubkey : dlcOffer.fundingPubkey,
@@ -2608,9 +2625,11 @@ Payout Group not found even with brute force search',
       finalCet = this._ddk
         .signCet(
           this.convertTxToDdkTransaction(dlcTxs.cets[outcomeIndex]),
-          isOfferer
-            ? dlcAccept.cetAdaptorSignatures.sigs[outcomeIndex].encryptedSig
-            : dlcSign.cetAdaptorSignatures.sigs[outcomeIndex].encryptedSig,
+          this.getFullAdaptorSig(
+            isOfferer
+              ? dlcAccept.cetAdaptorSignatures.sigs[outcomeIndex]
+              : dlcSign.cetAdaptorSignatures.sigs[outcomeIndex],
+          ),
           oracleSignatures,
           Buffer.from(fundPrivateKey, 'hex'),
           isOfferer ? dlcAccept.fundingPubkey : dlcOffer.fundingPubkey,

--- a/tests/integration/dlc/ddk-oracle-test.ts
+++ b/tests/integration/dlc/ddk-oracle-test.ts
@@ -1,6 +1,10 @@
 import 'mocha';
 
 import {
+  DlcAccept,
+  DlcOffer,
+  DlcSign,
+  DlcTransactions,
   EnumeratedDescriptor,
   EnumEventDescriptor,
   OracleAnnouncement,
@@ -132,12 +136,14 @@ describe('DDK Oracle Compatibility', () => {
       eventId,
     );
 
-    // Execute the DLC with the oracle attestation
+    // Execute with messages round-tripped through serialization, as they
+    // arrive over the wire. Deserialization splits adaptor sigs into
+    // encryptedSig + dleqProof, which execute must recombine for DDK.
     const cet = await ddk2.dlc.execute(
-      dlcOffer,
-      dlcAccept,
-      dlcSign,
-      dlcTransactions,
+      DlcOffer.deserialize(dlcOffer.serialize()),
+      DlcAccept.deserialize(dlcAccept.serialize()),
+      DlcSign.deserialize(dlcSign.serialize()),
+      DlcTransactions.deserialize(dlcTransactions.serialize()),
       oracleAttestation,
       false,
     );


### PR DESCRIPTION
## Bug

`BitcoinDdkProvider.execute` (both enum and numeric paths in `FindAndSignCet`) passes `sig.encryptedSig` directly to `ddk.signCet`. DDK's `EcdsaAdaptorSignature::from_slice` expects the full **162-byte** adaptor signature.

- **Live message objects** work: the provider stuffs all 162 bytes into `encryptedSig` when creating sigs.
- **Deserialized messages break**: `@node-dlc/messaging` splits the signature on deserialize into `encryptedSig` (65) + `dleqProof` (97), so `signCet` receives 65 bytes and throws `InvalidSignature`.

Since the integration tests pass message objects in-memory end-to-end, this was invisible in CI — but any real flow that transports offer/accept/sign over the wire (i.e. every actual DLC peer setup) hits it on execute. Found while running a browser DLC wallet for the btc++ Toronto workshop, where messages round-trip as hex between tabs.

The verify path (`VerifyCetAdaptorAndRefundSigs`) already handles the split form (`{signature, proof}`), so only the two `signCet` call sites were affected.

## Fix

Add `getFullAdaptorSig`: concat `encryptedSig + dleqProof` when `dleqProof` is non-empty, pass-through otherwise (covers both live and deserialized objects). Applied at both `signCet` call sites.

## Test

The ddk integration test now round-trips offer/accept/sign/dlcTransactions through `serialize()`/`deserialize()` before `execute` — this reproduces the bug on master and passes with the fix.

Verified on testnet4 with a browser (wasm ddk-ts) client after applying this as a patch: fund [3ac4ea74…](https://mempool.space/testnet4/tx/3ac4ea74b35b947302e8585a5204dd32d7cfbb5fbe1f090cd7189888d5ea849a) / CET [373fe440…](https://mempool.space/testnet4/tx/373fe440015f1434ea36291ff10c772d04adef94da07bd262083c25eabb3cc51).