### PR TITLE
fix: harden fixed input sweep transactions

### DIFF
--- a/.changeset/harden-fixed-input-sweeps.md
+++ b/.changeset/harden-fixed-input-sweeps.md
@@ -1,0 +1,5 @@
+---
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+---
+
+Build fixed-input sweep transactions from the supplied inputs with address-aware fee sizing and final transaction fees.

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -1,7 +1,6 @@
 import {
   decodeRawTransaction,
   normalizeTransactionObject,
-  selectCoins,
 } from '@atomicfinance/bitcoin-utils';
 import BitcoinWalletProvider from '@atomicfinance/bitcoin-wallet-provider';
 import Provider from '@atomicfinance/provider';
@@ -426,7 +425,8 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
         fixedOutputVbytes +
         sweepOutputVbytes,
     );
-    const amountToSend = utxoBalance - Math.ceil(_feePerByte * transactionVbytes);
+    const amountToSend =
+      utxoBalance - Math.ceil(_feePerByte * transactionVbytes);
 
     const targets = _outputs.map((target) => ({
       id: 'main',
@@ -518,7 +518,10 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
 
     const tx = psbt.extractTransaction();
     const inputValue = inputs.reduce((total, input) => total + input.value, 0);
-    const outputValue = tx.outs.reduce((total, output) => total + output.value, 0);
+    const outputValue = tx.outs.reduce(
+      (total, output) => total + output.value,
+      0,
+    );
 
     return { hex: tx.toHex(), fee: inputValue - outputValue };
   }
@@ -645,7 +648,8 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       externalChangeAddress,
       this._network,
     );
-    const outputVbytes = 8 + compactSizeBytes(outputScript.length) + outputScript.length;
+    const outputVbytes =
+      8 + compactSizeBytes(outputScript.length) + outputScript.length;
     const inputVbytes = this._getSweepInputVbytes();
     let fee = Math.ceil(
       (TX_OVERHEAD_VBYTES + inputs.length * inputVbytes + outputVbytes) *
@@ -698,7 +702,9 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
   }
 
   _getTxOverheadVbytes(inputCount: number, outputCount: number) {
-    return 4 + 0.5 + compactSizeBytes(inputCount) + compactSizeBytes(outputCount) + 4;
+    return (
+      4 + 0.5 + compactSizeBytes(inputCount) + compactSizeBytes(outputCount) + 4
+    );
   }
 
   async _buildTransactionWithInputs(

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -408,7 +408,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     inputs: bT.UTXO[];
     outputs: { value: number; id?: string }[];
     fee: number;
-    change: { value: number; id?: string };
+    change?: { value: number; id?: string };
   } {
     const utxoBalance = fixedInputs.reduce((a, b) => a + (b['value'] || 0), 0);
     const outputBalance = _outputs.reduce((a, b) => a + (b['value'] || 0), 0);
@@ -432,16 +432,20 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       id: 'main',
       value: target.value,
     }));
-    if (amountToSend - outputBalance > 0) {
-      targets.push({ id: 'main', value: amountToSend - outputBalance });
+    const sweepRemainder = amountToSend - outputBalance;
+    if (sweepAddress && sweepRemainder < CONSERVATIVE_DUST_THRESHOLD) {
+      throw new Error('Not enough balance');
     }
 
-    return selectCoins(
-      fixedInputs,
-      targets,
-      Math.ceil(_feePerByte),
-      fixedInputs,
-    );
+    if (sweepRemainder > 0) {
+      targets.push({ id: 'main', value: sweepRemainder });
+    }
+
+    return {
+      inputs: fixedInputs as unknown as bT.UTXO[],
+      outputs: targets,
+      fee: Math.ceil(_feePerByte * transactionVbytes),
+    };
   }
 
   async _buildTransactionWithoutUtxoCheck(

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -35,6 +35,13 @@ const LEGACY_INPUT_VBYTES = 148;
 const TX_OVERHEAD_VBYTES = 10.5;
 const CONSERVATIVE_DUST_THRESHOLD = 546;
 
+const compactSizeBytes = (count: number) => {
+  if (count < 253) return 1;
+  if (count <= 0xffff) return 3;
+  if (count <= 0xffffffff) return 5;
+  return 9;
+};
+
 type WalletProviderConstructor<T = Provider> = new (...args: unknown[]) => T;
 
 interface BitcoinJsWalletProviderOptions {
@@ -368,21 +375,22 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
         _outputs,
         _feePerByte,
         fixedInputs,
+        externalChangeAddress,
       );
       inputs.push(
         ...(inputsForAmount.inputs.map((utxo) => Input.fromUTXO(utxo)) || []),
       );
       outputs.push(...(inputsForAmount.outputs || []));
     }
-    _outputs.forEach((output) => {
-      const spliceIndex = outputs.findIndex(
-        (sweepOutput: Output) => output.value === sweepOutput.value,
-      );
-      outputs.splice(spliceIndex, 1);
-    });
+    const sweepOutput = outputs[_outputs.length];
+    if (!sweepOutput?.value) {
+      throw new Error('Not enough balance');
+    }
+
+    // TODO: Stop mutating caller-owned outputs in a future breaking cleanup.
     _outputs.push({
       to: externalChangeAddress,
-      value: outputs[0].value,
+      value: sweepOutput.value,
     });
     return this._buildTransactionWithoutUtxoCheck(
       _outputs,
@@ -395,6 +403,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     _outputs: Output[],
     _feePerByte: number,
     fixedInputs: Input[],
+    sweepAddress?: string,
   ): {
     inputs: bT.UTXO[];
     outputs: { value: number; id?: string }[];
@@ -403,9 +412,21 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
   } {
     const utxoBalance = fixedInputs.reduce((a, b) => a + (b['value'] || 0), 0);
     const outputBalance = _outputs.reduce((a, b) => a + (b['value'] || 0), 0);
-    const amountToSend =
-      utxoBalance -
-      _feePerByte * ((_outputs.length + 1) * 39 + fixedInputs.length * 153); // todo better calculation
+    const fixedOutputVbytes = _outputs.reduce(
+      (total, output) => total + this._getOutputVbytes(output.to),
+      0,
+    );
+    const sweepOutputVbytes = sweepAddress
+      ? this._getOutputVbytes(sweepAddress)
+      : 0;
+    const outputCount = _outputs.length + (sweepAddress ? 1 : 0);
+    const transactionVbytes = Math.ceil(
+      this._getTxOverheadVbytes(fixedInputs.length, outputCount) +
+        fixedInputs.length * this._getSweepInputVbytes() +
+        fixedOutputVbytes +
+        sweepOutputVbytes,
+    );
+    const amountToSend = utxoBalance - Math.ceil(_feePerByte * transactionVbytes);
 
     const targets = _outputs.map((target) => ({
       id: 'main',
@@ -429,12 +450,6 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
     fixedInputs: Input[],
   ) {
     const network = this._network;
-
-    const { fee } = this._getInputForAmountWithoutUtxoCheck(
-      outputs,
-      feePerByte,
-      fixedInputs,
-    );
     const inputs = fixedInputs;
 
     const psbt = new Psbt({ network });
@@ -497,7 +512,11 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
 
     psbt.finalizeAllInputs();
 
-    return { hex: psbt.extractTransaction().toHex(), fee };
+    const tx = psbt.extractTransaction();
+    const inputValue = inputs.reduce((total, input) => total + input.value, 0);
+    const outputValue = tx.outs.reduce((total, output) => total + output.value, 0);
+
+    return { hex: tx.toHex(), fee: inputValue - outputValue };
   }
 
   async _buildTransaction(
@@ -622,7 +641,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       externalChangeAddress,
       this._network,
     );
-    const outputVbytes = 8 + 1 + outputScript.length;
+    const outputVbytes = 8 + compactSizeBytes(outputScript.length) + outputScript.length;
     const inputVbytes = this._getSweepInputVbytes();
     let fee = Math.ceil(
       (TX_OVERHEAD_VBYTES + inputs.length * inputVbytes + outputVbytes) *
@@ -665,6 +684,17 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       return P2SH_SEGWIT_INPUT_VBYTES;
     }
     return P2WPKH_INPUT_VBYTES;
+  }
+
+  _getOutputVbytes(address?: string) {
+    if (!address) return 0;
+    bitcoin.initEccLib(getEcc() as never);
+    const outputScript = bitcoin.address.toOutputScript(address, this._network);
+    return 8 + compactSizeBytes(outputScript.length) + outputScript.length;
+  }
+
+  _getTxOverheadVbytes(inputCount: number, outputCount: number) {
+    return 4 + 0.5 + compactSizeBytes(inputCount) + compactSizeBytes(outputCount) + 4;
   }
 
   async _buildTransactionWithInputs(

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -381,6 +381,7 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       );
       outputs.push(...(inputsForAmount.outputs || []));
     }
+    // Coin selection preserves target order, so the sweep remainder follows the fixed outputs.
     const sweepOutput = outputs[_outputs.length];
     if (!sweepOutput?.value) {
       throw new Error('Not enough balance');

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -271,10 +271,8 @@ describe('Bitcoin Wallet provider', () => {
 
     it('preserves duplicate set output values before adding the sweep output', async () => {
       const fixedInputs = await mockFixedInputs([100000]);
-      const [firstOutput, secondOutput, destination] = await provider.getAddresses(
-        10,
-        3,
-      );
+      const [firstOutput, secondOutput, destination] =
+        await provider.getAddresses(10, 3);
       const setOutputs = [
         new Output(10000, firstOutput.address),
         new Output(10000, secondOutput.address),

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -1,6 +1,6 @@
 /* eslint-env mocha */
 
-import { Address } from '@atomicfinance/types';
+import { Address, Input, Output } from '@atomicfinance/types';
 import { generateMnemonic } from 'bip39';
 import { BitcoinNetworks } from 'bitcoin-network';
 import { Transaction } from 'bitcoinjs-lib';
@@ -218,6 +218,98 @@ describe('Bitcoin Wallet provider', () => {
       ).to.eventually.be.rejectedWith(
         'There should not be any change for sweeping transaction',
       );
+    });
+  });
+
+  describe('_buildSweepTransactionWithSetOutputs', () => {
+    const feeRate = 10;
+
+    const mockFixedInputs = async (values: number[]) => {
+      const addresses = await provider.getAddresses(0, values.length);
+      return addresses.map(
+        (address, index) =>
+          new Input(
+            Buffer.alloc(32, index + 1).toString('hex'),
+            0,
+            address.address,
+            values[index] / 1e8,
+            values[index],
+            address.derivationPath,
+          ),
+      );
+    };
+
+    beforeEach(() => {
+      provider.getInputsForAmount = async () => {
+        throw new Error('do not rescan');
+      };
+    });
+
+    it('sweeps exactly the provided fixed inputs', async () => {
+      const fixedInputs = await mockFixedInputs([100000, 200000]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      const { hex, fee } = await provider._buildSweepTransactionWithSetOutputs(
+        destination.address,
+        feeRate,
+        [],
+        fixedInputs,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = fixedInputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
+
+      expect(tx.ins).to.have.length(fixedInputs.length);
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].value).to.equal(inputValue - fee);
+      expect(fee).to.equal(
+        inputValue - tx.outs.reduce((total, output) => total + output.value, 0),
+      );
+    });
+
+    it('preserves duplicate set output values before adding the sweep output', async () => {
+      const fixedInputs = await mockFixedInputs([100000]);
+      const [firstOutput, secondOutput, destination] = await provider.getAddresses(
+        10,
+        3,
+      );
+      const setOutputs = [
+        new Output(10000, firstOutput.address),
+        new Output(10000, secondOutput.address),
+      ];
+
+      const { hex, fee } = await provider._buildSweepTransactionWithSetOutputs(
+        destination.address,
+        feeRate,
+        setOutputs,
+        fixedInputs,
+      );
+      const tx = Transaction.fromHex(hex);
+      const inputValue = fixedInputs.reduce(
+        (total, input) => total + input.value,
+        0,
+      );
+
+      expect(tx.outs).to.have.length(3);
+      expect(tx.outs[0].value).to.equal(10000);
+      expect(tx.outs[1].value).to.equal(10000);
+      expect(tx.outs[2].value).to.equal(inputValue - 20000 - fee);
+    });
+
+    it('rejects fixed-input sweeps whose remainder would be dust', async () => {
+      const fixedInputs = await mockFixedInputs([1500]);
+      const [destination] = await provider.getAddresses(10, 1);
+
+      await expect(
+        provider._buildSweepTransactionWithSetOutputs(
+          destination.address,
+          feeRate,
+          [],
+          fixedInputs,
+        ),
+      ).to.eventually.be.rejectedWith('Not enough balance');
     });
   });
 });


### PR DESCRIPTION
## Summary
- build fixed-input sweeps using exactly the supplied inputs when UTXO discovery is unavailable
- calculate sweep fees using address-aware output sizes, wallet input types, and CompactSize-aware overhead
- return the actual final transaction fee and preserve duplicate set-output values
- retain the existing caller-owned output mutation with a TODO for a future breaking cleanup
- add fixed-input sweep coverage for exact inputs, duplicate output values, and dust rejection

## Motivation
The app previews a Max sweep before confirmation and needs BAL to build and broadcast from those same selected inputs. Reusing the fixed inputs prevents a second wallet scan from including newly arrived UTXOs or failing due transient UTXO discovery timeouts.

## Validation
- 
> @atomicfinance/bitcoin-js-wallet-provider@4.3.3 build /Users/alex/projects/lygosbtc/bitcoin-abstraction-layer/packages/bitcoin-js-wallet-provider
> ../../node_modules/.bin/tsc --project tsconfig.json
- 
> @atomicfinance/bitcoin-js-wallet-provider@4.3.3 test /Users/alex/projects/lygosbtc/bitcoin-abstraction-layer/packages/bitcoin-js-wallet-provider
> ../../node_modules/.bin/nyc --reporter=lcov --reporter=text --extension=.ts ../../node_modules/.bin/mocha --recursive "tests/**/*.test.*"



  Bitcoin Wallet provider
    getDerivationCache
      ✔ should return derived addresses
    setDerivationCache
      ✔ should import to new client
      ✔ should fail if mnemonic doesn't match
    _buildSweepTransaction
      ✔ sweeps one P2WPKH input with no change output (168ms)
      ✔ sweeps multiple P2WPKH inputs with no change output (113ms)
      ✔ sweeps one P2WPKH input to a P2TR output with no change output (49ms)
      ✔ sweeps multiple P2WPKH inputs to a P2TR output with no change output (58ms)
      ✔ rejects P2WPKH sweeps that cannot cover fees
      ✔ rejects P2WPKH sweeps with a dust output
      ✔ rejects sweep coin selection that returns change
    _buildSweepTransactionWithSetOutputs
      ✔ sweeps exactly the provided fixed inputs (45ms)
      ✔ preserves duplicate set output values before adding the sweep output
      ✔ rejects fixed-input sweeps whose remainder would be dust


  13 passing (553ms)

----------------------------|---------|----------|---------|---------|------------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s            
----------------------------|---------|----------|---------|---------|------------------------------
All files                   |   54.66 |    34.66 |   48.97 |   54.21 |                              
 BitcoinJsWalletProvider.ts |   54.36 |    34.66 |   48.97 |   53.87 | ...8,736-739,743,751,780-855 
 index.ts                   |     100 |      100 |     100 |     100 |                              
----------------------------|---------|----------|---------|---------|------------------------------ (13 passing)

Follow-up to #210.