### PR TITLE
fix: preserve recipient sizing for fixed input sweeps

### DIFF
--- a/.changeset/fix-fixed-input-recipient-sizing.md
+++ b/.changeset/fix-fixed-input-recipient-sizing.md
@@ -1,0 +1,5 @@
+---
+'@atomicfinance/bitcoin-js-wallet-provider': patch
+---
+
+Build fixed-input sweeps without rediscovering UTXOs and size the sweep output from the actual recipient address.

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -350,36 +350,38 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       FEE_PER_BYTE_FALLBACK;
     const inputs: Input[] = [];
     const outputs: Output[] = [];
-    try {
-      const inputsForAmount = await this.getInputsForAmount(
-        _outputs,
-        _feePerByte,
-        fixedInputs as unknown as bT.Input[],
-        100,
-        true,
-      );
-      if (inputsForAmount.change) {
-        throw Error('There should not be any change for sweeping transaction');
-      }
-      inputs.push(...((inputsForAmount.inputs as Input[]) || []));
-      outputs.push(...(inputsForAmount.outputs || []));
-    } catch {
-      if (fixedInputs.length === 0) {
-        throw Error(
-          `Inputs for amount doesn't exist and no fixedInputs provided`,
-        );
-      }
-
-      const inputsForAmount = await this._getInputForAmountWithoutUtxoCheck(
+    if (fixedInputs.length > 0) {
+      const inputsForAmount = this._getInputForAmountWithoutUtxoCheck(
         _outputs,
         _feePerByte,
         fixedInputs,
         externalChangeAddress,
       );
       inputs.push(
-        ...(inputsForAmount.inputs.map((utxo) => Input.fromUTXO(utxo)) || []),
+        ...inputsForAmount.inputs.map((utxo) => Input.fromUTXO(utxo)),
       );
-      outputs.push(...(inputsForAmount.outputs || []));
+      outputs.push(...inputsForAmount.outputs);
+    } else {
+      try {
+        const inputsForAmount = await this.getInputsForAmount(
+          _outputs,
+          _feePerByte,
+          [],
+          100,
+          true,
+        );
+        if (inputsForAmount.change) {
+          throw Error(
+            'There should not be any change for sweeping transaction',
+          );
+        }
+        inputs.push(...((inputsForAmount.inputs as Input[]) || []));
+        outputs.push(...(inputsForAmount.outputs || []));
+      } catch {
+        throw Error(
+          `Inputs for amount doesn't exist and no fixedInputs provided`,
+        );
+      }
     }
     // Coin selection preserves target order, so the sweep remainder follows the fixed outputs.
     const sweepOutput = outputs[_outputs.length];

--- a/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
+++ b/packages/bitcoin-js-wallet-provider/lib/BitcoinJsWalletProvider.ts
@@ -362,26 +362,18 @@ export default class BitcoinJsWalletProvider extends BaseProvider {
       );
       outputs.push(...inputsForAmount.outputs);
     } else {
-      try {
-        const inputsForAmount = await this.getInputsForAmount(
-          _outputs,
-          _feePerByte,
-          [],
-          100,
-          true,
-        );
-        if (inputsForAmount.change) {
-          throw Error(
-            'There should not be any change for sweeping transaction',
-          );
-        }
-        inputs.push(...((inputsForAmount.inputs as Input[]) || []));
-        outputs.push(...(inputsForAmount.outputs || []));
-      } catch {
-        throw Error(
-          `Inputs for amount doesn't exist and no fixedInputs provided`,
-        );
+      const inputsForAmount = await this.getInputsForAmount(
+        _outputs,
+        _feePerByte,
+        [],
+        100,
+        true,
+      );
+      if (inputsForAmount.change) {
+        throw Error('There should not be any change for sweeping transaction');
       }
+      inputs.push(...((inputsForAmount.inputs as Input[]) || []));
+      outputs.push(...(inputsForAmount.outputs || []));
     }
     // Coin selection preserves target order, so the sweep remainder follows the fixed outputs.
     const sweepOutput = outputs[_outputs.length];

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -223,6 +223,9 @@ describe('Bitcoin Wallet provider', () => {
 
   describe('_buildSweepTransactionWithSetOutputs', () => {
     const feeRate = 10;
+    const taprootDestination =
+      'bcrt1p7yu5dsly83jg5tkxcljsa30vnpdpl22wr6rty98t6x6p6ekz2gkqcckz99';
+    let getInputsForAmountCalls: number;
 
     const mockFixedInputs = async (values: number[]) => {
       const addresses = await provider.getAddresses(0, values.length);
@@ -240,7 +243,9 @@ describe('Bitcoin Wallet provider', () => {
     };
 
     beforeEach(() => {
+      getInputsForAmountCalls = 0;
       provider.getInputsForAmount = async () => {
+        getInputsForAmountCalls++;
         throw new Error('do not rescan');
       };
     });
@@ -267,6 +272,25 @@ describe('Bitcoin Wallet provider', () => {
       expect(fee).to.equal(
         inputValue - tx.outs.reduce((total, output) => total + output.value, 0),
       );
+      expect(getInputsForAmountCalls).to.equal(0);
+    });
+
+    it('sizes a Taproot recipient without discovering inputs again', async () => {
+      const fixedInputs = await mockFixedInputs([100000]);
+
+      const { hex, fee } = await provider._buildSweepTransactionWithSetOutputs(
+        taprootDestination,
+        feeRate,
+        [],
+        fixedInputs,
+      );
+      const tx = Transaction.fromHex(hex);
+
+      expect(tx.outs).to.have.length(1);
+      expect(tx.outs[0].script.length).to.equal(34);
+      expect(fee).to.equal(1220);
+      expect(tx.outs[0].value).to.equal(fixedInputs[0].value - fee);
+      expect(getInputsForAmountCalls).to.equal(0);
     });
 
     it('preserves duplicate set output values before adding the sweep output', async () => {

--- a/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
+++ b/packages/bitcoin-js-wallet-provider/tests/unit/index.test.ts
@@ -333,5 +333,70 @@ describe('Bitcoin Wallet provider', () => {
         ),
       ).to.eventually.be.rejectedWith('Not enough balance');
     });
+
+    it('discovers inputs when fixed inputs are not provided', async () => {
+      const discoveredInputs = await mockFixedInputs([100000]);
+      const [destination] = await provider.getAddresses(10, 1);
+      provider.getInputsForAmount = async () => {
+        getInputsForAmountCalls++;
+        return {
+          inputs: discoveredInputs,
+          outputs: [{ id: 'main', value: 98000 }],
+          change: undefined,
+          fee: 2000,
+        };
+      };
+
+      const { hex, fee } = await provider._buildSweepTransactionWithSetOutputs(
+        destination.address,
+        feeRate,
+        [],
+        [],
+      );
+      const tx = Transaction.fromHex(hex);
+
+      expect(getInputsForAmountCalls).to.equal(1);
+      expect(tx.ins).to.have.length(1);
+      expect(tx.outs[0].value).to.equal(98000);
+      expect(fee).to.equal(2000);
+    });
+
+    it('preserves discovery errors when fixed inputs are not provided', async () => {
+      const [destination] = await provider.getAddresses(10, 1);
+      provider.getInputsForAmount = async () => {
+        throw new Error('rpc unavailable');
+      };
+
+      await expect(
+        provider._buildSweepTransactionWithSetOutputs(
+          destination.address,
+          feeRate,
+          [],
+          [],
+        ),
+      ).to.eventually.be.rejectedWith('rpc unavailable');
+    });
+
+    it('preserves the no-change sweep guard after input discovery', async () => {
+      const discoveredInputs = await mockFixedInputs([100000]);
+      const [destination] = await provider.getAddresses(10, 1);
+      provider.getInputsForAmount = async () => ({
+        inputs: discoveredInputs,
+        outputs: [{ id: 'main', value: 98000 }],
+        change: { value: 1000 },
+        fee: 1000,
+      });
+
+      await expect(
+        provider._buildSweepTransactionWithSetOutputs(
+          destination.address,
+          feeRate,
+          [],
+          [],
+        ),
+      ).to.eventually.be.rejectedWith(
+        'There should not be any change for sweeping transaction',
+      );
+    });
   });
 });


### PR DESCRIPTION
## Summary
- bypass UTXO discovery when fixed sweep inputs are supplied
- build the sweep remainder directly from the supplied inputs and actual recipient address
- preserve the existing discovery path for sweeps without fixed inputs
- add regression coverage for zero discovery calls and Taproot recipient sizing
- add a patch changeset for the wallet provider

## Motivation
Selected-input Max sweeps pass the recipient separately from fixed outputs. Rediscovering inputs through `getInputsForAmount([])` loses recipient script metadata and falls back to P2WPKH output sizing, which can underpay fees for Taproot or legacy recipients.

## Validation
- `pnpm lint`
- `pnpm --filter @atomicfinance/bitcoin-js-wallet-provider build`
- `pnpm --filter @atomicfinance/bitcoin-js-wallet-provider test` (14 passing)
- `pnpm exec changeset status`

Follow-up to #213.